### PR TITLE
Implement recommendation API and database seeding

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""planting-planner backend application package."""

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+DEFAULT_DB_FILENAME = "planting.db"
+
+
+def get_db_path() -> Path:
+    env_path = os.getenv("PLANTING_DB_PATH")
+    if env_path:
+        return Path(env_path)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    return DATA_DIR / DEFAULT_DB_FILENAME
+
+
+def connect(readonly: bool = False) -> sqlite3.Connection:
+    path = get_db_path()
+    if readonly:
+        uri = f"file:{path.as_posix()}?mode=ro"
+        connection = sqlite3.connect(uri, uri=True, check_same_thread=False)
+    else:
+        connection = sqlite3.connect(path, check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS crops (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            category TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS growth_days (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            crop_id INTEGER NOT NULL,
+            region TEXT NOT NULL,
+            days INTEGER NOT NULL,
+            UNIQUE (crop_id, region),
+            FOREIGN KEY (crop_id) REFERENCES crops(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS prices (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            crop_id INTEGER NOT NULL,
+            week INTEGER NOT NULL,
+            price REAL NOT NULL,
+            source TEXT NOT NULL,
+            FOREIGN KEY (crop_id) REFERENCES crops(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS etl_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_at TEXT NOT NULL,
+            status TEXT NOT NULL,
+            updated_records INTEGER NOT NULL,
+            error_message TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_prices_crop_week ON prices(crop_id, week);
+        """
+    )
+    conn.commit()

--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def run(conn: Any) -> int:
+    updated_records = conn.execute("SELECT COUNT(*) FROM prices").fetchone()[0]
+    conn.execute(
+        "INSERT INTO etl_runs (run_at, status, updated_records, error_message) VALUES (?, ?, ?, ?)",
+        (_utc_now(), "success", int(updated_records), None),
+    )
+    conn.commit()
+    return int(updated_records)
+
+
+def latest_status(conn: Any) -> dict[str, Any]:
+    row = conn.execute(
+        "SELECT run_at, status, updated_records, error_message FROM etl_runs ORDER BY run_at DESC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return {"last_run": None, "status": "stale", "updated_records": 0}
+    return {
+        "last_run": row["run_at"],
+        "status": row["status"],
+        "updated_records": int(row["updated_records"]),
+        "error_message": row["error_message"],
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,108 @@
-from fastapi import FastAPI
+from __future__ import annotations
+
+import sqlite3
+from typing import Generator
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+
+from . import db, etl, seed, utils_week
+from . import schemas
+
 
 app = FastAPI(title="planting-planner API")
+
+
+@app.on_event("startup")
+def startup() -> None:
+    conn = db.connect()
+    try:
+        db.init_db(conn)
+        seed.seed(conn)
+    finally:
+        conn.close()
+
+
+def get_conn() -> Generator[sqlite3.Connection, None, None]:
+    conn = db.connect()
+    _ensure_seeded(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _ensure_seeded(conn: sqlite3.Connection) -> None:
+    exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='crops'"
+    ).fetchone()
+    if exists is None:
+        db.init_db(conn)
+        seed.seed(conn)
 
 
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/crops", response_model=list[schemas.Crop])
+def list_crops(conn: sqlite3.Connection = Depends(get_conn)) -> list[schemas.Crop]:
+    rows = conn.execute("SELECT id, name, category FROM crops ORDER BY name").fetchall()
+    return [schemas.Crop(id=row["id"], name=row["name"], category=row["category"]) for row in rows]
+
+
+@app.get("/recommend", response_model=schemas.RecommendResponse)
+def recommend(
+    week: int | None = Query(default=None, description="Sowing week in YYYYWW format"),
+    region: schemas.Region = Query(default=schemas.Region.temperate),
+    conn: sqlite3.Connection = Depends(get_conn),
+) -> schemas.RecommendResponse:
+    target_week = week or utils_week.current_week()
+    try:
+        utils_week.week_to_date(target_week)
+    except utils_week.WeekFormatError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    rows = conn.execute(
+        """
+        SELECT c.name, gd.days, p.week AS harvest_week, p.source
+        FROM crops AS c
+        INNER JOIN growth_days AS gd ON gd.crop_id = c.id AND gd.region = ?
+        INNER JOIN prices AS p ON p.crop_id = c.id
+        """,
+        (region.value,),
+    ).fetchall()
+
+    items: list[schemas.RecommendationItem] = []
+    for row in rows:
+        weeks_to_harvest = utils_week.weeks_from_days(int(row["days"]))
+        sowing_week = utils_week.subtract_weeks(int(row["harvest_week"]), weeks_to_harvest)
+        if sowing_week != target_week:
+            continue
+        items.append(
+            schemas.RecommendationItem(
+                crop=row["name"],
+                harvest_week=int(row["harvest_week"]),
+                sowing_week=sowing_week,
+                source=row["source"],
+            )
+        )
+
+    items.sort(key=lambda item: (item.harvest_week, item.crop))
+    return schemas.RecommendResponse(week=target_week, region=region, items=items)
+
+
+@app.post("/refresh", response_model=schemas.RefreshResponse)
+def refresh(conn: sqlite3.Connection = Depends(get_conn)) -> schemas.RefreshResponse:
+    etl.run(conn)
+    return schemas.RefreshResponse(status="refresh started")
+
+
+@app.get("/refresh/status", response_model=schemas.RefreshStatusResponse)
+def refresh_status(conn: sqlite3.Connection = Depends(get_conn)) -> schemas.RefreshStatusResponse:
+    status = etl.latest_status(conn)
+    return schemas.RefreshStatusResponse(
+        last_run=status.get("last_run"),
+        status=status.get("status", "stale"),
+        updated_records=int(status.get("updated_records", 0)),
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Region(str, Enum):
+    cold = "cold"
+    temperate = "temperate"
+    warm = "warm"
+
+
+class Crop(BaseModel):
+    id: int
+    name: str
+    category: str
+
+
+class RecommendationItem(BaseModel):
+    crop: str
+    harvest_week: int
+    sowing_week: int
+    source: str
+
+
+class RecommendResponse(BaseModel):
+    week: int
+    region: Region
+    items: list[RecommendationItem]
+
+
+class RefreshResponse(BaseModel):
+    status: str
+
+
+class RefreshStatusResponse(BaseModel):
+    last_run: str | None
+    status: Literal["success", "failure", "running", "stale"]
+    updated_records: int

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from . import db
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+
+def _load_json(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, list):
+        raise ValueError(f"Expected list in {path}")
+    return [dict(item) for item in payload]
+
+
+def seed(conn: sqlite3.Connection) -> None:
+    crops_path = DATA_DIR / "crops.json"
+    growth_days_path = DATA_DIR / "growth_days.json"
+
+    crops_data = _load_json(crops_path)
+    growth_days_data = _load_json(growth_days_path)
+
+    conn.execute("DELETE FROM growth_days")
+    conn.execute("DELETE FROM prices")
+    conn.execute("DELETE FROM crops")
+
+    name_to_id: dict[str, int] = {}
+    for crop in crops_data:
+        name = crop["name"]
+        category = crop["category"]
+        cursor = conn.execute(
+            "INSERT INTO crops (name, category) VALUES (?, ?)",
+            (name, category),
+        )
+        crop_id = int(cursor.lastrowid)
+        name_to_id[name] = crop_id
+
+        for price in crop.get("prices", []):
+            conn.execute(
+                "INSERT INTO prices (crop_id, week, price, source) VALUES (?, ?, ?, ?)",
+                (crop_id, int(price["week"]), float(price["price"]), price["source"]),
+            )
+
+    for entry in growth_days_data:
+        crop_name = entry["crop"]
+        crop_id = name_to_id.get(crop_name)
+        if crop_id is None:
+            raise KeyError(f"growth_days refers to unknown crop '{crop_name}'")
+        conn.execute(
+            "INSERT OR REPLACE INTO growth_days (crop_id, region, days) VALUES (?, ?, ?)",
+            (crop_id, entry["region"], int(entry["days"])),
+        )
+
+    conn.commit()
+
+
+def seed_from_default_db() -> None:
+    conn = db.connect()
+    try:
+        seed(conn)
+    finally:
+        conn.close()

--- a/backend/app/utils_week.py
+++ b/backend/app/utils_week.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+
+class WeekFormatError(ValueError):
+    pass
+
+
+def _split_week(week: int) -> tuple[int, int]:
+    week_str = str(week)
+    if len(week_str) != 6:
+        raise WeekFormatError("week must be in YYYYWW format")
+    year = int(week_str[:4])
+    week_number = int(week_str[4:])
+    if not 1 <= week_number <= 53:
+        raise WeekFormatError("week number must be between 1 and 53")
+    return year, week_number
+
+
+def week_to_date(week: int) -> date:
+    year, week_number = _split_week(week)
+    return date.fromisocalendar(year, week_number, 1)
+
+
+def date_to_week(value: date) -> int:
+    iso = value.isocalendar()
+    return iso.year * 100 + iso.week
+
+
+def add_weeks(week: int, delta: int) -> int:
+    base = week_to_date(week)
+    new_date = base + timedelta(weeks=delta)
+    return date_to_week(new_date)
+
+
+def subtract_weeks(week: int, delta: int) -> int:
+    return add_weeks(week, -delta)
+
+
+def weeks_from_days(days: int) -> int:
+    if days <= 0:
+        return 0
+    return (days + 6) // 7
+
+
+def current_week() -> int:
+    return date_to_week(date.today())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.115.0
+httpx==0.27.2
 uvicorn[standard]==0.30.6

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_recommend_default_region_uses_temperate_growth_days() -> None:
+    response = client.get("/recommend", params={"week": 202432})
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["week"] == 202432
+    assert payload["region"] == "temperate"
+
+    items = payload["items"]
+    assert len(items) == 2
+
+    spinach, tomato = items
+    assert spinach == {
+        "crop": "ほうれん草",
+        "harvest_week": 202440,
+        "sowing_week": 202432,
+        "source": "e-Stat",
+    }
+    assert tomato == {
+        "crop": "トマト",
+        "harvest_week": 202448,
+        "sowing_week": 202432,
+        "source": "JA Aichi",
+    }
+
+
+def test_recommend_allows_region_override() -> None:
+    response = client.get("/recommend", params={"week": 202430, "region": "cold"})
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["week"] == 202430
+    assert payload["region"] == "cold"
+
+    items = payload["items"]
+    assert len(items) == 2
+
+    spinach, tomato = items
+    assert spinach["crop"] == "ほうれん草"
+    assert spinach["harvest_week"] == 202440
+    assert spinach["sowing_week"] == 202430
+    assert spinach["source"] == "e-Stat"
+
+    assert tomato["crop"] == "トマト"
+    assert tomato["harvest_week"] == 202448
+    assert tomato["sowing_week"] == 202430
+    assert tomato["source"] == "JA Aichi"

--- a/data/crops.json
+++ b/data/crops.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "ほうれん草",
+    "category": "leaf",
+    "prices": [
+      { "week": 202440, "price": 260.0, "source": "e-Stat" },
+      { "week": 202448, "price": 240.0, "source": "e-Stat" }
+    ]
+  },
+  {
+    "name": "にんじん",
+    "category": "root",
+    "prices": [
+      { "week": 202442, "price": 210.0, "source": "e-Stat" }
+    ]
+  },
+  {
+    "name": "トマト",
+    "category": "fruit",
+    "prices": [
+      { "week": 202448, "price": 520.0, "source": "JA Aichi" }
+    ]
+  },
+  {
+    "name": "マリーゴールド",
+    "category": "flower",
+    "prices": [
+      { "week": 202438, "price": 180.0, "source": "MAFF" }
+    ]
+  }
+]

--- a/data/growth_days.json
+++ b/data/growth_days.json
@@ -1,0 +1,14 @@
+[
+  { "crop": "ほうれん草", "region": "cold", "days": 70 },
+  { "crop": "ほうれん草", "region": "temperate", "days": 56 },
+  { "crop": "ほうれん草", "region": "warm", "days": 49 },
+  { "crop": "にんじん", "region": "cold", "days": 90 },
+  { "crop": "にんじん", "region": "temperate", "days": 80 },
+  { "crop": "にんじん", "region": "warm", "days": 75 },
+  { "crop": "トマト", "region": "cold", "days": 120 },
+  { "crop": "トマト", "region": "temperate", "days": 110 },
+  { "crop": "トマト", "region": "warm", "days": 100 },
+  { "crop": "マリーゴールド", "region": "cold", "days": 85 },
+  { "crop": "マリーゴールド", "region": "temperate", "days": 70 },
+  { "crop": "マリーゴールド", "region": "warm", "days": 60 }
+]


### PR DESCRIPTION
## Summary
- add SQLite schema helpers and seed loaders backed by crops/growth days datasets
- implement week utilities, ETL stubs, and FastAPI endpoints for crops, recommendations, and refresh status
- cover recommendation behaviour with region-aware pytest cases

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dc9b3ab0088321948c6cc5916c1cee