### PR TITLE
Switch recommend API to ISO week schedule

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -20,13 +20,13 @@ class Crop(BaseModel):
 
 class RecommendationItem(BaseModel):
     crop: str
-    harvest_week: int
-    sowing_week: int
-    source: str
+    harvest_week: str
+    sowing_week: str
+    source: str = "internal"
 
 
 class RecommendResponse(BaseModel):
-    week: int
+    week: str
     region: Region
     items: list[RecommendationItem]
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,10 +1,12 @@
 from fastapi.testclient import TestClient
+
 from app.main import app
+
 
 client = TestClient(app)
 
 
-def test_health():
-    r = client.get("/health")
+def test_health() -> None:
+    r = client.get("/api/health")
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -1,55 +1,109 @@
+from __future__ import annotations
+
+import re
+
 from fastapi.testclient import TestClient
 
 from app.main import app
 
 
 client = TestClient(app)
+ISO_WEEK_PATTERN = re.compile(r"^\d{4}-W\d{2}$")
 
 
-def test_recommend_default_region_uses_temperate_growth_days() -> None:
-    response = client.get("/recommend", params={"week": 202432})
+def _assert_iso_week(value: str) -> None:
+    assert ISO_WEEK_PATTERN.fullmatch(value), value
+
+
+def test_recommend_default_region_returns_temperate_schedule() -> None:
+    response = client.get("/api/recommend")
     assert response.status_code == 200
 
     payload = response.json()
-    assert payload["week"] == 202432
     assert payload["region"] == "temperate"
+    _assert_iso_week(payload["week"])
 
     items = payload["items"]
-    assert len(items) == 2
+    assert items == [
+        {
+            "crop": "マリーゴールド",
+            "harvest_week": "2024-W38",
+            "sowing_week": "2024-W28",
+            "source": "MAFF",
+        },
+        {
+            "crop": "ほうれん草",
+            "harvest_week": "2024-W40",
+            "sowing_week": "2024-W32",
+            "source": "e-Stat",
+        },
+        {
+            "crop": "にんじん",
+            "harvest_week": "2024-W42",
+            "sowing_week": "2024-W30",
+            "source": "e-Stat",
+        },
+        {
+            "crop": "ほうれん草",
+            "harvest_week": "2024-W48",
+            "sowing_week": "2024-W40",
+            "source": "e-Stat",
+        },
+        {
+            "crop": "トマト",
+            "harvest_week": "2024-W48",
+            "sowing_week": "2024-W32",
+            "source": "JA Aichi",
+        },
+    ]
 
-    spinach, tomato = items
-    assert spinach == {
-        "crop": "ほうれん草",
-        "harvest_week": 202440,
-        "sowing_week": 202432,
-        "source": "e-Stat",
-    }
-    assert tomato == {
-        "crop": "トマト",
-        "harvest_week": 202448,
-        "sowing_week": 202432,
-        "source": "JA Aichi",
-    }
+    for item in items:
+        _assert_iso_week(item["harvest_week"])
+        _assert_iso_week(item["sowing_week"])
 
 
 def test_recommend_allows_region_override() -> None:
-    response = client.get("/recommend", params={"week": 202430, "region": "cold"})
+    response = client.get("/api/recommend", params={"region": "cold"})
     assert response.status_code == 200
 
     payload = response.json()
-    assert payload["week"] == 202430
     assert payload["region"] == "cold"
+    _assert_iso_week(payload["week"])
 
     items = payload["items"]
-    assert len(items) == 2
+    assert items == [
+        {
+            "crop": "マリーゴールド",
+            "harvest_week": "2024-W38",
+            "sowing_week": "2024-W25",
+            "source": "MAFF",
+        },
+        {
+            "crop": "ほうれん草",
+            "harvest_week": "2024-W40",
+            "sowing_week": "2024-W30",
+            "source": "e-Stat",
+        },
+        {
+            "crop": "にんじん",
+            "harvest_week": "2024-W42",
+            "sowing_week": "2024-W29",
+            "source": "e-Stat",
+        },
+        {
+            "crop": "ほうれん草",
+            "harvest_week": "2024-W48",
+            "sowing_week": "2024-W38",
+            "source": "e-Stat",
+        },
+        {
+            "crop": "トマト",
+            "harvest_week": "2024-W48",
+            "sowing_week": "2024-W30",
+            "source": "JA Aichi",
+        },
+    ]
 
-    spinach, tomato = items
-    assert spinach["crop"] == "ほうれん草"
-    assert spinach["harvest_week"] == 202440
-    assert spinach["sowing_week"] == 202430
-    assert spinach["source"] == "e-Stat"
-
-    assert tomato["crop"] == "トマト"
-    assert tomato["harvest_week"] == 202448
-    assert tomato["sowing_week"] == 202430
-    assert tomato["source"] == "JA Aichi"
+    for item in items:
+        _assert_iso_week(item["harvest_week"])
+        _assert_iso_week(item["sowing_week"])


### PR DESCRIPTION
## Summary
- move public endpoints under the /api prefix and update recommend logic to back-calculate sowing weeks from harvest data
- emit ISO week strings in recommend response models with a default source value and updated schemas/utilities
- refresh recommendation tests to validate ISO week formatting for the default and alternate regions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcadafb2108321a4f520415971ee5d