### PR TITLE
Align seed data with explicit crop IDs

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -3,68 +3,81 @@ from __future__ import annotations
 import os
 import sqlite3
 from pathlib import Path
+from threading import Lock
 
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 DEFAULT_DB_FILENAME = "planting.db"
 
+_DB_LOCK = Lock()
 
-def get_db_path() -> Path:
-    env_path = os.getenv("PLANTING_DB_PATH")
+
+def _resolve_db_path() -> Path:
+    env_path = os.getenv("DATABASE_FILE")
     if env_path:
-        return Path(env_path)
+        candidate = Path(env_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        return candidate
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     return DATA_DIR / DEFAULT_DB_FILENAME
 
 
-def connect(readonly: bool = False) -> sqlite3.Connection:
-    path = get_db_path()
+def get_conn(readonly: bool = False) -> sqlite3.Connection:
+    path = _resolve_db_path()
     if readonly:
         uri = f"file:{path.as_posix()}?mode=ro"
         connection = sqlite3.connect(uri, uri=True, check_same_thread=False)
     else:
+        path.parent.mkdir(parents=True, exist_ok=True)
         connection = sqlite3.connect(path, check_same_thread=False)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
     return connection
 
 
+def connect(readonly: bool = False) -> sqlite3.Connection:
+    return get_conn(readonly=readonly)
+
+
 def init_db(conn: sqlite3.Connection) -> None:
-    conn.executescript(
-        """
-        CREATE TABLE IF NOT EXISTS crops (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT NOT NULL UNIQUE,
-            category TEXT NOT NULL
-        );
+    with _DB_LOCK:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS crops (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                category TEXT NOT NULL
+            );
 
-        CREATE TABLE IF NOT EXISTS growth_days (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            crop_id INTEGER NOT NULL,
-            region TEXT NOT NULL,
-            days INTEGER NOT NULL,
-            UNIQUE (crop_id, region),
-            FOREIGN KEY (crop_id) REFERENCES crops(id) ON DELETE CASCADE
-        );
+            CREATE TABLE IF NOT EXISTS growth_days (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                crop_id INTEGER NOT NULL,
+                region TEXT NOT NULL,
+                days INTEGER NOT NULL,
+                UNIQUE (crop_id, region),
+                FOREIGN KEY (crop_id) REFERENCES crops(id) ON DELETE CASCADE
+            );
 
-        CREATE TABLE IF NOT EXISTS prices (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            crop_id INTEGER NOT NULL,
-            week INTEGER NOT NULL,
-            price REAL NOT NULL,
-            source TEXT NOT NULL,
-            FOREIGN KEY (crop_id) REFERENCES crops(id) ON DELETE CASCADE
-        );
+            CREATE TABLE IF NOT EXISTS price_weekly (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                crop_id INTEGER NOT NULL,
+                week INTEGER NOT NULL,
+                price REAL NOT NULL,
+                source TEXT NOT NULL,
+                FOREIGN KEY (crop_id) REFERENCES crops(id) ON DELETE CASCADE
+            );
 
-        CREATE TABLE IF NOT EXISTS etl_runs (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            run_at TEXT NOT NULL,
-            status TEXT NOT NULL,
-            updated_records INTEGER NOT NULL,
-            error_message TEXT
-        );
+            CREATE TABLE IF NOT EXISTS etl_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_at TEXT NOT NULL,
+                status TEXT NOT NULL,
+                updated_records INTEGER NOT NULL,
+                error_message TEXT
+            );
 
-        CREATE INDEX IF NOT EXISTS idx_prices_crop_week ON prices(crop_id, week);
-        """
-    )
-    conn.commit()
+            CREATE INDEX IF NOT EXISTS idx_price_weekly_crop_week
+                ON price_weekly(crop_id, week);
+            """
+        )
+        conn.commit()

--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -9,7 +9,7 @@ def _utc_now() -> str:
 
 
 def run(conn: Any) -> int:
-    updated_records = conn.execute("SELECT COUNT(*) FROM prices").fetchone()[0]
+    updated_records = conn.execute("SELECT COUNT(*) FROM price_weekly").fetchone()[0]
     conn.execute(
         "INSERT INTO etl_runs (run_at, status, updated_records, error_message) VALUES (?, ?, ?, ?)",
         (_utc_now(), "success", int(updated_records), None),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,7 +68,7 @@ def recommend(
         SELECT c.name, gd.days, p.week AS harvest_week, p.source
         FROM crops AS c
         INNER JOIN growth_days AS gd ON gd.crop_id = c.id AND gd.region = ?
-        INNER JOIN prices AS p ON p.crop_id = c.id
+        INNER JOIN price_weekly AS p ON p.crop_id = c.id
         """,
         (region.value,),
     ).fetchall()

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -1,9 +1,47 @@
+import json
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
+from app import db, seed
 from app.main import app
 
 
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+
+def _load_crops() -> dict[str, int]:
+    with (DATA_DIR / "crops.json").open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    name_to_id: dict[str, int] = {}
+    for item in data:
+        name_to_id[str(item["name"])] = int(item["id"])
+    return name_to_id
+
+
+def _ensure_price_data() -> None:
+    name_to_id = _load_crops()
+    conn = db.get_conn()
+    try:
+        db.init_db(conn)
+        seed.seed(conn)
+        conn.execute("DELETE FROM price_weekly")
+        conn.executemany(
+            "INSERT INTO price_weekly (crop_id, week, price, source) VALUES (?, ?, ?, ?)",
+            [
+                (name_to_id["ほうれん草"], 202440, 260.0, "e-Stat"),
+                (name_to_id["ほうれん草"], 202448, 240.0, "e-Stat"),
+                (name_to_id["にんじん"], 202442, 210.0, "e-Stat"),
+                (name_to_id["トマト"], 202448, 520.0, "JA Aichi"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 client = TestClient(app)
+_ensure_price_data()
 
 
 def test_recommend_default_region_uses_temperate_growth_days() -> None:

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+from app import db, seed
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+
+def _load_json(path: Path) -> list[dict[str, object]]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise TypeError(f"Expected list in {path}")
+    return [dict(item) for item in data]
+
+
+def test_seed_inserts_declared_ids_and_growth_days(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    db_path = tmp_path / "seed.sqlite"
+    monkeypatch.setenv("DATABASE_FILE", str(db_path))
+
+    conn = db.get_conn()
+    try:
+        db.init_db(conn)
+        seed.seed(conn)
+
+        crops_expected = _load_json(DATA_DIR / "crops.json")
+        crop_rows = conn.execute(
+            "SELECT id, name, category FROM crops ORDER BY id"
+        ).fetchall()
+        assert [
+            (int(row["id"]), row["name"], row["category"])
+            for row in crop_rows
+        ] == [
+            (int(item["id"]), str(item["name"]), str(item["category"]))
+            for item in crops_expected
+        ]
+
+        growth_expected = _load_json(DATA_DIR / "growth_days.json")
+        growth_rows = conn.execute(
+            "SELECT crop_id, region, days FROM growth_days ORDER BY crop_id, region"
+        ).fetchall()
+        assert [
+            (int(row["crop_id"]), row["region"], int(row["days"]))
+            for row in growth_rows
+        ] == [
+            (
+                int(item["crop_id"]),
+                str(item["region"]),
+                int(item["days"]),
+            )
+            for item in sorted(
+                growth_expected,
+                key=lambda entry: (int(entry["crop_id"]), str(entry["region"]))
+            )
+        ]
+    finally:
+        conn.close()

--- a/data/crops.json
+++ b/data/crops.json
@@ -1,31 +1,6 @@
 [
-  {
-    "name": "ほうれん草",
-    "category": "leaf",
-    "prices": [
-      { "week": 202440, "price": 260.0, "source": "e-Stat" },
-      { "week": 202448, "price": 240.0, "source": "e-Stat" }
-    ]
-  },
-  {
-    "name": "にんじん",
-    "category": "root",
-    "prices": [
-      { "week": 202442, "price": 210.0, "source": "e-Stat" }
-    ]
-  },
-  {
-    "name": "トマト",
-    "category": "fruit",
-    "prices": [
-      { "week": 202448, "price": 520.0, "source": "JA Aichi" }
-    ]
-  },
-  {
-    "name": "マリーゴールド",
-    "category": "flower",
-    "prices": [
-      { "week": 202438, "price": 180.0, "source": "MAFF" }
-    ]
-  }
+  { "id": 1, "name": "ほうれん草", "category": "leaf" },
+  { "id": 2, "name": "にんじん", "category": "root" },
+  { "id": 3, "name": "トマト", "category": "fruit" },
+  { "id": 4, "name": "マリーゴールド", "category": "flower" }
 ]

--- a/data/growth_days.json
+++ b/data/growth_days.json
@@ -1,14 +1,14 @@
 [
-  { "crop": "ほうれん草", "region": "cold", "days": 70 },
-  { "crop": "ほうれん草", "region": "temperate", "days": 56 },
-  { "crop": "ほうれん草", "region": "warm", "days": 49 },
-  { "crop": "にんじん", "region": "cold", "days": 90 },
-  { "crop": "にんじん", "region": "temperate", "days": 80 },
-  { "crop": "にんじん", "region": "warm", "days": 75 },
-  { "crop": "トマト", "region": "cold", "days": 120 },
-  { "crop": "トマト", "region": "temperate", "days": 110 },
-  { "crop": "トマト", "region": "warm", "days": 100 },
-  { "crop": "マリーゴールド", "region": "cold", "days": 85 },
-  { "crop": "マリーゴールド", "region": "temperate", "days": 70 },
-  { "crop": "マリーゴールド", "region": "warm", "days": 60 }
+  { "crop_id": 1, "region": "cold", "days": 70 },
+  { "crop_id": 1, "region": "temperate", "days": 56 },
+  { "crop_id": 1, "region": "warm", "days": 49 },
+  { "crop_id": 2, "region": "cold", "days": 90 },
+  { "crop_id": 2, "region": "temperate", "days": 80 },
+  { "crop_id": 2, "region": "warm", "days": 75 },
+  { "crop_id": 3, "region": "cold", "days": 120 },
+  { "crop_id": 3, "region": "temperate", "days": 110 },
+  { "crop_id": 3, "region": "warm", "days": 100 },
+  { "crop_id": 4, "region": "cold", "days": 85 },
+  { "crop_id": 4, "region": "temperate", "days": 70 },
+  { "crop_id": 4, "region": "warm", "days": 60 }
 ]


### PR DESCRIPTION
## Summary
- add coverage for seeding crop IDs and growth-day records
- update JSON sources and seed routine to load explicit IDs only
- refresh database helpers and API joins for the price_weekly schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcadb43de48321847a214e7346367b