### PR TITLE
feat: track refresh job status

### DIFF
--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -1,32 +1,149 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from . import db
+
+STATE_RUNNING = "running"
+STATE_SUCCESS = "success"
+STATE_FAILURE = "failure"
 
 
 def _utc_now() -> str:
-    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def run(conn: Any) -> int:
-    updated_records = conn.execute("SELECT COUNT(*) FROM prices").fetchone()[0]
-    conn.execute(
-        "INSERT INTO etl_runs (run_at, status, updated_records, error_message) VALUES (?, ?, ?, ?)",
-        (_utc_now(), "success", int(updated_records), None),
-    )
-    conn.commit()
-    return int(updated_records)
+def _ensure_schema(conn: Any) -> None:
+    columns = {row[1] for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()}
+    migrations: dict[str, str] = {
+        "state": "ALTER TABLE etl_runs ADD COLUMN state TEXT",
+        "started_at": "ALTER TABLE etl_runs ADD COLUMN started_at TEXT",
+        "finished_at": "ALTER TABLE etl_runs ADD COLUMN finished_at TEXT",
+        "last_error": "ALTER TABLE etl_runs ADD COLUMN last_error TEXT",
+    }
+    mutated = False
+    for column, ddl in migrations.items():
+        if column not in columns:
+            conn.execute(ddl)
+            mutated = True
+    if mutated:
+        conn.commit()
 
 
-def latest_status(conn: Any) -> dict[str, Any]:
+def run_etl(conn: Any) -> int:
+    row = conn.execute("SELECT COUNT(*) FROM prices").fetchone()
+    if row is None:
+        return 0
+    value = row[0]
+    if value is None:
+        return 0
+    return int(value)
+
+
+def start_etl_job() -> None:
+    conn = db.connect()
+    try:
+        _ensure_schema(conn)
+        started_at = _utc_now()
+        cursor = conn.execute(
+            """
+            INSERT INTO etl_runs (
+                run_at,
+                status,
+                updated_records,
+                error_message,
+                state,
+                started_at,
+                finished_at,
+                last_error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (started_at, STATE_RUNNING, 0, None, STATE_RUNNING, started_at, None, None),
+        )
+        run_id_raw = cursor.lastrowid
+        if run_id_raw is None:  # pragma: no cover - SQLite guarantees an id for AUTOINCREMENT
+            raise RuntimeError("Failed to persist ETL run metadata")
+        run_id = int(run_id_raw)
+        conn.commit()
+
+        try:
+            updated_records = run_etl(conn)
+        except Exception as exc:  # pragma: no cover - defensive path
+            finished_at = _utc_now()
+            error_message = str(exc)
+            conn.execute(
+                """
+                UPDATE etl_runs
+                SET status = ?,
+                    state = ?,
+                    finished_at = ?,
+                    last_error = ?,
+                    error_message = ?
+                WHERE id = ?
+                """,
+                (STATE_FAILURE, STATE_FAILURE, finished_at, error_message, error_message, run_id),
+            )
+            conn.commit()
+            raise
+        else:
+            finished_at = _utc_now()
+            conn.execute(
+                """
+                UPDATE etl_runs
+                SET status = ?,
+                    state = ?,
+                    finished_at = ?,
+                    updated_records = ?,
+                    last_error = NULL,
+                    error_message = NULL
+                WHERE id = ?
+                """,
+                (STATE_SUCCESS, STATE_SUCCESS, finished_at, updated_records, run_id),
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def get_last_status(conn: Any) -> dict[str, Any]:
+    _ensure_schema(conn)
     row = conn.execute(
-        "SELECT run_at, status, updated_records, error_message FROM etl_runs ORDER BY run_at DESC LIMIT 1"
+        """
+        SELECT
+            COALESCE(state, status) AS state,
+            COALESCE(started_at, run_at) AS started_at,
+            finished_at,
+            updated_records,
+            COALESCE(last_error, error_message) AS last_error,
+            run_at
+        FROM etl_runs
+        ORDER BY COALESCE(started_at, run_at) DESC
+        LIMIT 1
+        """,
     ).fetchone()
     if row is None:
-        return {"last_run": None, "status": "stale", "updated_records": 0}
+        return {
+            "last_run": None,
+            "status": "stale",
+            "state": "stale",
+            "started_at": None,
+            "finished_at": None,
+            "updated_records": 0,
+            "last_error": None,
+        }
+
+    state = (row["state"] or "stale").lower()
+    finished_at = row["finished_at"]
+    last_run = finished_at if finished_at is not None else None
+    raw_updated_records = cast(int | None, row["updated_records"])
+    updated_records = 0 if raw_updated_records is None else int(raw_updated_records)
     return {
-        "last_run": row["run_at"],
-        "status": row["status"],
-        "updated_records": int(row["updated_records"]),
-        "error_message": row["error_message"],
+        "last_run": last_run,
+        "status": state,
+        "state": state,
+        "started_at": row["started_at"],
+        "finished_at": finished_at,
+        "updated_records": updated_records,
+        "last_error": row["last_error"],
     }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -36,6 +36,10 @@ class RefreshResponse(BaseModel):
 
 
 class RefreshStatusResponse(BaseModel):
-    last_run: str | None
     status: Literal["success", "failure", "running", "stale"]
+    state: Literal["success", "failure", "running", "stale"]
+    last_run: str | None
+    started_at: str | None = None
+    finished_at: str | None = None
     updated_records: int
+    last_error: str | None = None

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from app import db, seed
+from app.main import app
+
+client = TestClient(app)
+
+
+def _reset_etl_runs() -> None:
+    conn = db.connect()
+    try:
+        try:
+            conn.execute("DELETE FROM etl_runs")
+        except sqlite3.OperationalError:
+            db.init_db(conn)
+            seed.seed(conn)
+            conn.execute("DELETE FROM etl_runs")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _parse_utc(timestamp: str | None) -> datetime | None:
+    if timestamp is None:
+        return None
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def setup_function(_: object) -> None:
+    _reset_etl_runs()
+
+
+def teardown_function(_: object) -> None:
+    _reset_etl_runs()
+
+
+def test_refresh_status_returns_default_payload() -> None:
+    response = client.get("/refresh/status")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["status"] == "stale"
+    assert payload["state"] == "stale"
+    assert payload["last_run"] is None
+    assert payload["started_at"] is None
+    assert payload["finished_at"] is None
+    assert payload["updated_records"] == 0
+    assert payload["last_error"] is None
+
+
+def test_refresh_triggers_background_job_and_updates_status() -> None:
+    response = client.post("/refresh")
+    assert response.status_code == 200
+    assert response.json() == {"status": "refresh started"}
+
+    status_response = client.get("/refresh/status")
+    assert status_response.status_code == 200
+
+    payload = status_response.json()
+    assert payload["status"] == "success"
+    assert payload["state"] == "success"
+    assert payload["last_error"] is None
+    assert payload["updated_records"] >= 0
+
+    started_at = _parse_utc(payload["started_at"])
+    finished_at = _parse_utc(payload["finished_at"])
+    last_run = _parse_utc(payload["last_run"])
+
+    assert started_at is not None
+    assert finished_at is not None
+    assert last_run == finished_at
+    assert started_at <= finished_at


### PR DESCRIPTION
## Summary
- add regression coverage for /refresh and /refresh/status endpoints
- implement background ETL job tracking with persisted status metadata
- extend the refresh status schema to expose the recorded job fields

## Testing
- pytest backend/tests
- ruff check app/etl.py tests/test_refresh.py
- mypy app/etl.py

------
https://chatgpt.com/codex/tasks/task_e_68dcadb581208321a8fad88b047a0481