### PR TITLE
Separate backend lint checks from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           name: planting-planner-frontend-dist
           path: frontend/dist
 
-  backend:
-    name: backend (fastapi+pytest)
+  backend-lint:
+    name: backend lint (ruff+black+mypy)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -53,5 +53,19 @@ jobs:
         run: black --check .
       - name: type check (mypy)
         run: mypy app
+
+  backend-test:
+    name: backend test (pytest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -r requirements.txt -r requirements-dev.txt
       - name: test (pytest)
         run: pytest -q

--- a/backend/tests/test_ci_config.py
+++ b/backend/tests/test_ci_config.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_backend_ci_has_separate_lint_job() -> None:
+    ci_config = (Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "backend-lint:" in ci_config
+    assert "backend-test:" in ci_config


### PR DESCRIPTION
## Summary
- add a regression test that ensures the backend CI config defines dedicated lint and test jobs
- split the backend workflow into backend-lint and backend-test jobs so coding standard checks run independently of pytest

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dcb076ce90832186ba16101e38d7af