### PR TITLE
Refine refresh API status handling

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,15 +31,9 @@ class RecommendResponse(BaseModel):
     items: list[RecommendationItem]
 
 
-class RefreshResponse(BaseModel):
-    status: str
-
-
-class RefreshStatusResponse(BaseModel):
-    status: Literal["success", "failure", "running", "stale"]
+class RefreshStatus(BaseModel):
     state: Literal["success", "failure", "running", "stale"]
-    last_run: str | None
     started_at: str | None = None
     finished_at: str | None = None
-    updated_records: int
+    updated_records: int = 0
     last_error: str | None = None

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -40,38 +40,39 @@ def teardown_function(_: object) -> None:
 
 
 def test_refresh_status_returns_default_payload() -> None:
-    response = client.get("/refresh/status")
+    response = client.get("/api/refresh/status")
     assert response.status_code == 200
 
     payload = response.json()
-    assert payload["status"] == "stale"
-    assert payload["state"] == "stale"
-    assert payload["last_run"] is None
-    assert payload["started_at"] is None
-    assert payload["finished_at"] is None
-    assert payload["updated_records"] == 0
-    assert payload["last_error"] is None
+    assert payload == {
+        "state": "stale",
+        "started_at": None,
+        "finished_at": None,
+        "updated_records": 0,
+        "last_error": None,
+    }
 
 
 def test_refresh_triggers_background_job_and_updates_status() -> None:
-    response = client.post("/refresh")
+    response = client.post("/api/refresh")
     assert response.status_code == 200
-    assert response.json() == {"status": "refresh started"}
+    assert response.json() == {"state": "running"}
 
-    status_response = client.get("/refresh/status")
+    status_response = client.get("/api/refresh/status")
     assert status_response.status_code == 200
 
     payload = status_response.json()
-    assert payload["status"] == "success"
-    assert payload["state"] == "success"
+    assert payload["state"] in {"running", "success"}
     assert payload["last_error"] is None
     assert payload["updated_records"] >= 0
 
     started_at = _parse_utc(payload["started_at"])
     finished_at = _parse_utc(payload["finished_at"])
-    last_run = _parse_utc(payload["last_run"])
 
-    assert started_at is not None
-    assert finished_at is not None
-    assert last_run == finished_at
-    assert started_at <= finished_at
+    if payload["state"] == "running":
+        assert started_at is not None
+        assert finished_at is None
+    else:
+        assert started_at is not None
+        assert finished_at is not None
+        assert started_at <= finished_at


### PR DESCRIPTION
## Summary
- update refresh tests to cover the new /api/refresh and /api/refresh/status payloads
- add the RefreshStatus schema and adjust ETL tracking to return it
- trigger ETL runs via background tasks and expose the latest status through the API

## Testing
- pytest backend/tests/test_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68dcbfa43ad483219d358ef9662d409f