### PR TITLE
feat: manual fetch with favorite-first sorting

### DIFF
--- a/frontend/src/components/FavStar.tsx
+++ b/frontend/src/components/FavStar.tsx
@@ -1,3 +1,7 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import { loadFavorites, saveFavorites } from '../lib/storage'
+
 interface Props {
   active: boolean
   cropName: string
@@ -20,3 +24,29 @@ export const FavStar = ({ active, cropName, onToggle }: Props) => {
 }
 
 FavStar.displayName = 'FavStar'
+
+export const useFavorites = () => {
+  const [favorites, setFavorites] = useState<number[]>(() => loadFavorites())
+
+  const toggleFavorite = useCallback((cropId?: number) => {
+    if (!cropId) {
+      return
+    }
+    setFavorites((prev) => {
+      const exists = prev.includes(cropId)
+      const next = exists ? prev.filter((id) => id !== cropId) : [...prev, cropId]
+      saveFavorites(next)
+      return next
+    })
+  }, [])
+
+  const isFavorite = useCallback(
+    (cropId?: number) => (cropId !== undefined ? favorites.includes(cropId) : false),
+    [favorites],
+  )
+
+  return useMemo(
+    () => ({ favorites, toggleFavorite, isFavorite }),
+    [favorites, isFavorite, toggleFavorite],
+  )
+}

--- a/frontend/src/components/RegionSelect.tsx
+++ b/frontend/src/components/RegionSelect.tsx
@@ -1,5 +1,6 @@
-import type { ChangeEvent } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 
+import { loadRegion, saveRegion } from '../lib/storage'
 import type { Region, RegionOption } from '../types'
 
 const DEFAULT_OPTIONS: RegionOption[] = [
@@ -9,15 +10,22 @@ const DEFAULT_OPTIONS: RegionOption[] = [
 ]
 
 interface Props {
-  value: Region
   onChange: (region: Region) => void
   options?: RegionOption[]
   disabled?: boolean
 }
 
-export const RegionSelect = ({ value, onChange, options = DEFAULT_OPTIONS, disabled }: Props) => {
+export const RegionSelect = ({ onChange, options = DEFAULT_OPTIONS, disabled }: Props) => {
+  const [selected, setSelected] = useState<Region>(() => loadRegion())
+
+  useEffect(() => {
+    onChange(selected)
+  }, [onChange, selected])
+
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    onChange(event.target.value as Region)
+    const next = event.target.value as Region
+    setSelected(next)
+    saveRegion(next)
   }
 
   return (
@@ -26,7 +34,7 @@ export const RegionSelect = ({ value, onChange, options = DEFAULT_OPTIONS, disab
       <select
         aria-label="地域"
         className="region-select__select"
-        value={value}
+        value={selected}
         onChange={handleChange}
         disabled={disabled}
       >


### PR DESCRIPTION
## Summary
- add a manual recommendation fetch flow that prioritizes favourites in the result table
- persist region selection inside RegionSelect and expose a favourites hook for reuse
- update the integration test to cover the new manual fetch and favourite ordering behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcbfa160088321a6f89e1f19b7e8fc