### PR TITLE
Fix frontend tests for updated recommendation API

### DIFF
--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Crop, RecommendResponse, Region } from './types'
 
 vi.mock('./lib/week', () => ({
-  currentIsoWeek: () => '2024-W30',
+  getCurrentIsoWeek: () => '2024-W30',
   normalizeIsoWeek: (value: string) => value,
   formatIsoWeek: (value: string) => value,
   compareIsoWeek: (a: string, b: string) => a.localeCompare(b),
@@ -38,14 +38,14 @@ vi.mock('./lib/storage', () => ({
   saveFavorites,
 }))
 
-const fetchRecommend = vi.fn<
-  (input: { region: Region; week?: string }) => Promise<RecommendResponse>
+const fetchRecommendations = vi.fn<
+  (region: Region, week?: string) => Promise<RecommendResponse>
 >()
 const fetchCrops = vi.fn<() => Promise<Crop[]>>()
 const postRefresh = vi.fn<() => Promise<string>>()
 
 vi.mock('./lib/api', () => ({
-  fetchRecommend,
+  fetchRecommendations,
   fetchCrops,
   postRefresh,
 }))
@@ -57,7 +57,7 @@ const resetSpies = () => {
   saveRegion.mockClear()
   loadFavorites.mockClear()
   saveFavorites.mockClear()
-  fetchRecommend.mockReset()
+  fetchRecommendations.mockReset()
   fetchCrops.mockReset()
   postRefresh.mockReset()
 }
@@ -75,7 +75,7 @@ describe('App', () => {
     const App = (await import('./App')).default
     const user = userEvent.setup()
     render(<App />)
-    await waitFor(() => expect(fetchRecommend).toHaveBeenCalled())
+    await waitFor(() => expect(fetchCrops).toHaveBeenCalled())
     return { user }
   }
 
@@ -84,7 +84,7 @@ describe('App', () => {
       { id: 1, name: '春菊', category: 'leaf' },
       { id: 2, name: 'にんじん', category: 'root' },
     ])
-    fetchRecommend.mockImplementation(async ({ region }) => ({
+    fetchRecommendations.mockImplementation(async (region) => ({
       week: '2024-W30',
       region,
       items: [
@@ -99,9 +99,13 @@ describe('App', () => {
 
     const { user } = await renderApp()
 
-    expect(fetchRecommend).toHaveBeenLastCalledWith({
-      region: 'temperate',
-      week: '2024-W30',
+    const submit = screen.getByRole('button', { name: 'この条件で見る' })
+    expect(fetchRecommendations).not.toHaveBeenCalled()
+
+    await user.click(submit)
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W30')
     })
 
     const select = screen.getByLabelText('地域')
@@ -112,7 +116,7 @@ describe('App', () => {
     await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
 
     await waitFor(() => {
-      expect(fetchRecommend).toHaveBeenLastCalledWith({ region: 'cold', week: '2024-W32' })
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('cold', '2024-W32')
     })
     expect(saveRegion).toHaveBeenLastCalledWith('cold')
     expect(screen.getByText('にんじん')).toBeInTheDocument()
@@ -125,7 +129,7 @@ describe('App', () => {
       { id: 1, name: '春菊', category: 'leaf' },
       { id: 2, name: 'にんじん', category: 'root' },
     ])
-    fetchRecommend.mockResolvedValue({
+    fetchRecommendations.mockResolvedValue({
       week: '2024-W30',
       region: 'temperate',
       items: [
@@ -146,6 +150,8 @@ describe('App', () => {
 
     const { user } = await renderApp()
 
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
     const toggle = screen.getByRole('button', { name: 'にんじんをお気に入りに追加' })
     await user.click(toggle)
 
@@ -161,7 +167,7 @@ describe('App', () => {
       { id: 3, name: 'キャベツ', category: 'leaf' },
     ])
 
-    fetchRecommend.mockResolvedValue({
+    fetchRecommendations.mockResolvedValue({
       week: '2024-W30',
       region: 'temperate',
 
@@ -189,6 +195,14 @@ describe('App', () => {
 
     const { user } = await renderApp()
 
+    const submit = screen.getByRole('button', { name: 'この条件で見る' })
+    await user.click(submit)
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalled()
+    })
+
+    fetchRecommendations.mockClear()
     expect(fetchRecommendations).not.toHaveBeenCalled()
 
     const select = screen.getByLabelText('地域')
@@ -207,12 +221,17 @@ describe('App', () => {
 
     const table = await screen.findByRole('table')
     const rows = within(table).getAllByRole('row').slice(1)
+    const [firstRow, secondRow, thirdRow] = rows
 
-    expect(rows[0]).toHaveTextContent('にんじん')
-    expect(rows[1]).toHaveTextContent('春菊')
-    expect(rows[2]).toHaveTextContent('キャベツ')
+    if (!firstRow || !secondRow || !thirdRow) {
+      throw new Error('推奨テーブルの行が不足しています')
+    }
 
-    const favToggle = within(rows[1]).getByRole('button', { name: '春菊をお気に入りに追加' })
+    expect(firstRow).toHaveTextContent('にんじん')
+    expect(secondRow).toHaveTextContent('春菊')
+    expect(thirdRow).toHaveTextContent('キャベツ')
+
+    const favToggle = within(secondRow).getByRole('button', { name: '春菊をお気に入りに追加' })
     await user.click(favToggle)
 
     expect(saveFavorites).toHaveBeenLastCalledWith([2, 1])


### PR DESCRIPTION
## Summary
- frontend の App テストを新しい fetchRecommendations シグネチャと手動フェッチ動作に合わせて更新
- 推奨表ソート検証の安全性を高めるためテーブル行取得時に明示チェックを追加

## Testing
- npm run lint
- npm run typecheck
- npm test
- ruff check . *(失敗: backend 側の既存未対応箇所によるエラー)*
- black --check . *(失敗: backend 側の既存未対応箇所によるエラー)*
- mypy app *(失敗: backend schemas に未定義の型が存在)*
- pytest -q *(失敗: backend schemas に未定義の型が存在)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc30139ec8321be6439f9efd569b0