### PR TITLE
Adjust recommend logic to use growth days schedule

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,39 +52,34 @@ def list_crops(conn: sqlite3.Connection = Depends(get_conn)) -> list[schemas.Cro
 @app.get("/api/recommend", response_model=schemas.RecommendResponse)
 def recommend(
     week: str | None = Query(default=None, description="Reference week in ISO format YYYY-Www"),
-    region: schemas.Region = Query(default=schemas.Region.temperate),
+    region: schemas.Region = Query(default=schemas.DEFAULT_REGION),
     conn: sqlite3.Connection = Depends(get_conn),
 ) -> schemas.RecommendResponse:
     reference_week = week or utils_week.current_iso_week()
     try:
-        utils_week.iso_week_to_date(reference_week)
+        utils_week.iso_week_to_date_mid(reference_week)
     except utils_week.WeekFormatError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     rows = conn.execute(
         """
-        SELECT c.name, gd.days, pw.week AS harvest_week, pw.source
+        SELECT c.name, gd.days
         FROM crops AS c
         INNER JOIN growth_days AS gd ON gd.crop_id = c.id AND gd.region = ?
-        INNER JOIN price_weekly AS pw ON pw.crop_id = c.id
-        ORDER BY pw.week, c.name
+        ORDER BY c.name
         """,
-        (region.value,),
+        (region,),
     ).fetchall()
 
-    items: list[schemas.RecommendationItem] = []
+    items: list[schemas.RecommendItem] = []
     for row in rows:
-        harvest_week_iso = utils_week.iso_week_from_int(int(row["harvest_week"]))
-        sowing_week_iso = utils_week.subtract_days_from_week(
-            harvest_week_iso, int(row["days"])
-        )
-        source = row["source"] or "internal"
+        days = int(row["days"])
         items.append(
-            schemas.RecommendationItem(
+            schemas.RecommendItem(
                 crop=row["name"],
-                harvest_week=harvest_week_iso,
-                sowing_week=sowing_week_iso,
-                source=source,
+                growth_days=days,
+                harvest_week=reference_week,
+                sowing_week=utils_week.subtract_days_to_iso_week(reference_week, days),
             )
         )
 
@@ -110,7 +105,7 @@ def refresh_legacy(_conn: sqlite3.Connection = Depends(get_conn)) -> schemas.Ref
 
 def _refresh_status(conn: sqlite3.Connection) -> schemas.RefreshStatusResponse:
     status = etl.get_last_status(conn)
-    return schemas.RefreshStatusResponse(**status)
+    return schemas.RefreshStatusResponse(**status.model_dump())
 
 
 @app.get("/api/refresh/status", response_model=schemas.RefreshStatusResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from enum import Enum
-from typing import Literal
+from typing import Literal, TypedDict
 
 from pydantic import BaseModel
 
 
-class Region(str, Enum):
-    cold = "cold"
-    temperate = "temperate"
-    warm = "warm"
+Region = Literal["cold", "temperate", "warm"]
+DEFAULT_REGION: Region = "temperate"
 
 
 class Crop(BaseModel):
@@ -18,8 +15,9 @@ class Crop(BaseModel):
     category: str
 
 
-class RecommendationItem(BaseModel):
+class RecommendItem(BaseModel):
     crop: str
+    growth_days: int
     harvest_week: str
     sowing_week: str
     source: str = "internal"
@@ -28,7 +26,11 @@ class RecommendationItem(BaseModel):
 class RecommendResponse(BaseModel):
     week: str
     region: Region
-    items: list[RecommendationItem]
+    items: list[RecommendItem]
+
+
+class RefreshResponse(TypedDict):
+    state: Literal["success", "failure", "running", "stale"]
 
 
 class RefreshStatus(BaseModel):
@@ -37,3 +39,6 @@ class RefreshStatus(BaseModel):
     finished_at: str | None = None
     updated_records: int = 0
     last_error: str | None = None
+
+
+RefreshStatusResponse = RefreshStatus

--- a/backend/app/utils_week.py
+++ b/backend/app/utils_week.py
@@ -24,20 +24,25 @@ def iso_week_to_date(week: str) -> date:
     return date.fromisocalendar(year, week_number, 1)
 
 
+def iso_week_to_date_mid(week: str) -> date:
+    base = iso_week_to_date(week)
+    return base + timedelta(days=2)
+
+
 def date_to_iso_week(value: date) -> str:
     iso = value.isocalendar()
     return f"{iso.year:04d}-W{iso.week:02d}"
 
 
-def subtract_days_from_week(week: str, days: int) -> str:
-    base_date = iso_week_to_date(week)
+def subtract_days_to_iso_week(week: str, days: int) -> str:
+    base_date = iso_week_to_date_mid(week)
     target_date = base_date - timedelta(days=days)
     return date_to_iso_week(target_date)
 
 
 def iso_week_from_int(week: int) -> str:
     iso_week = f"{week // 100:04d}-W{week % 100:02d}"
-    iso_week_to_date(iso_week)
+    iso_week_to_date_mid(iso_week)
     return iso_week
 
 

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -63,6 +63,7 @@ def _assert_items(payload: dict[str, object], region: str) -> None:
         assert item["harvest_week"] == REFERENCE_WEEK
         expected_sowing = _subtract_days(REFERENCE_WEEK, days)
         assert item["sowing_week"] == expected_sowing
+        assert item["growth_days"] == days
         _assert_iso_week(item["harvest_week"])
         _assert_iso_week(item["sowing_week"])
 


### PR DESCRIPTION
## Summary
- update week utilities to operate on the ISO mid-week reference and provide sowing helpers
- rewrite /api/recommend to derive schedules from growth_days using the request week as harvest target
- align recommendation schemas and tests with the new growth day based response

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dcc44b9e3883218d059f71b77683a3