### PR TITLE
Update environment variable docs for planting DB path

### DIFF
--- a/docs/spec/v0.1/DEVELOPMENT.md
+++ b/docs/spec/v0.1/DEVELOPMENT.md
@@ -31,7 +31,10 @@ uvicorn app.main:app --reload
 ## 環境変数
 
 * `.env` ファイルを backend に置く（必須ではないが拡張用）
-* `DATABASE_URL=sqlite:///./planting.db`
+* `PLANTING_DB_PATH=/abs/path/to/planting.db`
+  * FastAPI バックエンドが参照する SQLite ファイルへの絶対パスを指定する。
+  * 上記の例は SQLite ファイルを想定したパスであり、他の RDBMS を使用する場合は別途ドライバ設定を行う。
+  * 旧 `DATABASE_URL` は使用しない（互換用に残す場合は、同一 SQLite ファイルを指すように設定する）。
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the DATABASE_URL guidance with PLANTING_DB_PATH to match the current backend configuration
- clarify that the example points to a SQLite file and how to handle legacy DATABASE_URL setups

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dcc81e5d2c8321912dc330fd15d989