### PR TITLE
docs: align type spec with frontend typings

### DIFF
--- a/docs/spec/v0.1/TYPES.md
+++ b/docs/spec/v0.1/TYPES.md
@@ -29,10 +29,10 @@ export interface GrowthDays {
 ## 推奨結果
 
 ```ts
-export interface Recommendation {
+export interface RecommendationItem {
   crop: string
-  harvest_week: number
-  sowing_week: number
+  harvest_week: string
+  sowing_week: string
   source: string
 }
 ```
@@ -49,19 +49,25 @@ export interface HealthResponse {
 export type CropsResponse = Crop[]
 
 export interface RecommendResponse {
-  week: number
+  week: string
   region: Region
-  items: Recommendation[]
+  items: RecommendationItem[]
 }
 
 export interface RefreshResponse {
-  status: string
+  state: "success" | "failure" | "running" | "stale"
+  started_at?: string | null
+  finished_at?: string | null
+  updated_records?: number
+  last_error?: string | null
 }
 
 export interface RefreshStatusResponse {
-  last_run: string
-  status: "success" | "failure" | "running" | "stale"
+  state: "success" | "failure" | "running" | "stale"
+  started_at: string | null
+  finished_at: string | null
   updated_records: number
+  last_error: string | null
 }
 ```
 


### PR DESCRIPTION
## Summary
- update recommendation item typing to use string-based weeks and consistent naming
- align API response specs with frontend types for week and refresh status fields

## Testing
- not run (docs change only)

------
https://chatgpt.com/codex/tasks/task_e_68dcc81bd874832188aeff5f28471e73