### PR TITLE
feat: schedule refresh ETL via background tasks

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -143,21 +143,19 @@ def price_series(
     )
 
 
-def _start_refresh(_conn: sqlite3.Connection) -> schemas.RefreshResponse:
-    etl.start_etl_job()
-
-
+def _start_refresh(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
+    background_tasks.add_task(etl.start_etl_job)
     return {"state": etl.STATE_RUNNING}
 
 
 @app.post("/api/refresh", response_model=schemas.RefreshResponse)
-def refresh(_conn: sqlite3.Connection = Depends(get_conn)) -> schemas.RefreshResponse:
-    return _start_refresh(_conn)
+def refresh(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
+    return _start_refresh(background_tasks)
 
 
 @app.post("/refresh", response_model=schemas.RefreshResponse)
-def refresh_legacy(_conn: sqlite3.Connection = Depends(get_conn)) -> schemas.RefreshResponse:
-    return _start_refresh(_conn)
+def refresh_legacy(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
+    return _start_refresh(background_tasks)
 
 
 def _refresh_status(conn: sqlite3.Connection) -> schemas.RefreshStatusResponse:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,7 +15,7 @@ class Crop(BaseModel):
     category: str
 
 
-class RecommendItem(BaseModel):
+class RecommendationItem(BaseModel):
     crop: str
     growth_days: int
     harvest_week: str
@@ -26,7 +26,7 @@ class RecommendItem(BaseModel):
 class RecommendResponse(BaseModel):
     week: str
     region: Region
-    items: list[RecommendItem]
+    items: list[RecommendationItem]
 
 
 class RefreshResponse(TypedDict):


### PR DESCRIPTION
## Summary
- update the refresh endpoints to inject `BackgroundTasks` and schedule the ETL job asynchronously
- fix the recommendation schema alias so the FastAPI app imports cleanly during tests

## Testing
- `pytest -q` *(fails: backend/tests/test_recommend.py::test_recommend_default_region_returns_temperate_schedule, backend/tests/test_recommend.py::test_recommend_allows_region_override)*
- `ruff check backend/app/main.py` *(fails: pre-existing lint findings in recommend handler)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc81a8a34832182a65346fe1a0b83