### PR TITLE
Fix recommendation endpoint schedule computation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Generator
+from typing import Annotated
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query
 
@@ -38,22 +39,39 @@ def _ensure_seeded(conn: sqlite3.Connection) -> None:
         seed.seed(conn)
 
 
+ConnDependency = Annotated[sqlite3.Connection, Depends(get_conn)]
+RecommendWeekQuery = Annotated[
+    str | None, Query(description="Reference week in ISO format YYYY-Www")
+]
+RecommendRegionQuery = Annotated[
+    schemas.Region, Query(description="Growing region for the recommendation schedule")
+]
+PriceCropQuery = Annotated[int, Query(ge=1)]
+FromWeekQuery = Annotated[
+    str | None, Query(description="from ISO week e.g., 2025-W01")
+]
+ToWeekQuery = Annotated[
+    str | None, Query(description="to ISO week e.g., 2025-W52")
+]
+
+
 @app.get("/api/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
 @app.get("/api/crops", response_model=list[schemas.Crop])
-def list_crops(conn: sqlite3.Connection = Depends(get_conn)) -> list[schemas.Crop]:
+def list_crops(conn: ConnDependency) -> list[schemas.Crop]:
     rows = conn.execute("SELECT id, name, category FROM crops ORDER BY name").fetchall()
     return [schemas.Crop(id=row["id"], name=row["name"], category=row["category"]) for row in rows]
 
 
 @app.get("/api/recommend", response_model=schemas.RecommendResponse)
 def recommend(
-    week: str | None = Query(default=None, description="Reference week in ISO format YYYY-Www"),
-    region: schemas.Region = Query(default=schemas.DEFAULT_REGION),
-    conn: sqlite3.Connection = Depends(get_conn),
+    week: RecommendWeekQuery = None,
+    region: RecommendRegionQuery = schemas.DEFAULT_REGION,
+    *,
+    conn: ConnDependency,
 ) -> schemas.RecommendResponse:
     reference_week = week or utils_week.current_iso_week()
     try:
@@ -63,24 +81,20 @@ def recommend(
 
     rows = conn.execute(
         """
-        SELECT c.name, gd.days
+        SELECT DISTINCT c.name, gd.days
         FROM crops AS c
         INNER JOIN growth_days AS gd ON gd.crop_id = c.id AND gd.region = ?
         INNER JOIN price_weekly AS pw ON pw.crop_id = c.id AND pw.source != 'seed'
-        ORDER BY pw.week, c.name
+        ORDER BY c.name
         """,
         (region,),
     ).fetchall()
 
-    items: list[schemas.RecommendItem] = []
+    items: list[schemas.RecommendationItem] = []
     for row in rows:
-        harvest_week_iso = str(row["harvest_week"])
-        sowing_week_iso = utils_week.subtract_days_from_week(
-            harvest_week_iso, int(row["days"])
-        )
-        source = row["source"] or "internal"
+        days = int(row["days"])
         items.append(
-            schemas.RecommendItem(
+            schemas.RecommendationItem(
                 crop=row["name"],
                 growth_days=days,
                 harvest_week=reference_week,
@@ -93,10 +107,11 @@ def recommend(
 
 @app.get("/api/price", response_model=schemas.PriceSeries)
 def price_series(
-    crop_id: int = Query(..., ge=1),
-    frm: str | None = Query(None, description="from ISO week e.g., 2025-W01"),
-    to: str | None = Query(None, description="to ISO week e.g., 2025-W52"),
-    conn: sqlite3.Connection = Depends(get_conn),
+    crop_id: PriceCropQuery,
+    frm: FromWeekQuery = None,
+    to: ToWeekQuery = None,
+    *,
+    conn: ConnDependency,
 ) -> schemas.PriceSeries:
     crop_row = conn.execute(
         "SELECT id, name FROM crops WHERE id = ?",
@@ -166,10 +181,10 @@ def _refresh_status(conn: sqlite3.Connection) -> schemas.RefreshStatusResponse:
 
 
 @app.get("/api/refresh/status", response_model=schemas.RefreshStatusResponse)
-def refresh_status(conn: sqlite3.Connection = Depends(get_conn)) -> schemas.RefreshStatusResponse:
+def refresh_status(conn: ConnDependency) -> schemas.RefreshStatusResponse:
     return _refresh_status(conn)
 
 
 @app.get("/refresh/status", response_model=schemas.RefreshStatusResponse)
-def refresh_status_legacy(conn: sqlite3.Connection = Depends(get_conn)) -> schemas.RefreshStatusResponse:
+def refresh_status_legacy(conn: ConnDependency) -> schemas.RefreshStatusResponse:
     return _refresh_status(conn)

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import re
-
 from datetime import date, timedelta
 
 from fastapi.testclient import TestClient
 
 from app.main import app
-
 
 client = TestClient(app)
 ISO_WEEK_PATTERN = re.compile(r"^(\d{4})-W(\d{2})$")
@@ -64,6 +62,7 @@ def _assert_items(payload: dict[str, object], region: str) -> None:
         expected_sowing = _subtract_days(REFERENCE_WEEK, days)
         assert item["sowing_week"] == expected_sowing
         assert item["growth_days"] == days
+        assert item["source"] == "internal"
         _assert_iso_week(item["harvest_week"])
         _assert_iso_week(item["sowing_week"])
 


### PR DESCRIPTION
## Summary
- update the recommendation query to return distinct crops and compute sowing weeks directly from the requested reference week
- tighten FastAPI dependency injection by using `Annotated` helpers and align the price endpoint signature
- extend the recommendation API test to assert the default data source field

## Testing
- `ruff check .` *(fails: pre-existing lint errors in unrelated modules)*
- `black --check .` *(fails: formatting drift in existing backend files)*
- `mypy backend/app` *(fails: baseline typing issues in seed/etl/schemas modules)*
- `pytest`
- `npm run lint`
- `npm run typecheck` *(fails: baseline TypeScript errors in App.tsx and main.test.tsx)*
- `npm test` *(fails: duplicate symbol defined in src/main.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dcccf1acd083219767e6df3ad9f595