### PR TITLE
docs: update load spec for price_weekly table

### DIFF
--- a/docs/spec/v0.1/ETL_SPEC.md
+++ b/docs/spec/v0.1/ETL_SPEC.md
@@ -1,14 +1,17 @@
 # ETL 仕様 - planting-planner v0.1
 
 ## 処理概要
+
 ETL (Extract, Transform, Load) により、公的市場データを週単位に整形し SQLite に格納する。
 
 ## Extract
+
 - e-Stat API または CSV/Excel ダウンロード
 - 花きデータは農水省の公開ファイルから抽出
 - スケジュール: 手動「更新」ボタン → バックエンドで非同期実行
 
 ## Transform
+
 - 単位変換（例: 円/10本 → 円/kg）
 - 週番号（ISO 週）に丸め込み
 - 欠損値処理
@@ -16,18 +19,22 @@ ETL (Extract, Transform, Load) により、公的市場データを週単位に�
   - それも不可なら NULL のまま保持
 
 ## Load
+
 - SQLite に UPSERT
 - テーブル構造:
   - `crops`（作物マスタ）
-  - `prices`（市場価格）
+  - `price_weekly`（週単位価格。主キー `id` と `crop_id`×`week` の一意制約。
+    主なカラムは `avg_price`、`stddev`、`unit`、`source`）
   - `growth_days`（平均生育日数）
 
 ## エラーハンドリング
+
 - ダウンロード失敗 → リトライ3回まで
 - CSV フォーマット不一致 → スキップしてログ出力
 - 失敗時も DB は前回データを維持
 
 ## ログ
+
 - `etl_runs` テーブルに記録
   - `state`: ジョブの現在ステータス（`running`/`success`/`failure`）を保持
   - `started_at`: ジョブ開始時刻。マイグレーション後は従来の `run_at` と同値で初期化
@@ -38,4 +45,5 @@ ETL (Extract, Transform, Load) により、公的市場データを週単位に�
   - 更新件数
   - エラーメッセージ（失敗時）
 
-実装では失敗を検知すると `finished_at` と `last_error` を更新し、リトライ後に成功した場合でも `last_error` は `NULL` にリセットされる。これにより UI は最新のジョブ状態と直近の障害内容のみを参照できる。
+実装では失敗を検知すると `finished_at` と `last_error` を更新し、リトライ後に成功した場合でも
+`last_error` は `NULL` にリセットされる。これにより UI は最新のジョブ状態と直近の障害内容のみを参照できる。


### PR DESCRIPTION
## Summary
- update the Load section to document the price_weekly table instead of prices
- add column details for price_weekly and improve markdown spacing for lint compliance

## Testing
- npx --yes markdownlint-cli@0.38.0 docs/spec/v0.1/ETL_SPEC.md

------
https://chatgpt.com/codex/tasks/task_e_68dcccf02e308321bcc208b534e08816