### PR TITLE
Fix recommendation API mocks in main test

### DIFF
--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -51,12 +51,17 @@ const fetchCrops = vi.fn<() => Promise<Crop[]>>()
 const postRefresh = vi.fn<() => Promise<RefreshResponse>>()
 const fetchRefreshStatus = vi.fn<() => Promise<RefreshStatusResponse>>()
 
-const fetchRecommendations = vi.fn<
-  (region: Region, week?: string) => Promise<RecommendResponse>
->(async (region, week) => fetchRecommend({ region, week }))
+const fetchRecommend = vi.fn<
+  (input: { region: Region; week?: string }) => Promise<RecommendResponse>
+>()
+
+fetchRecommendations.mockImplementation(async (region, week) =>
+  fetchRecommend({ region, week }),
+)
 
 vi.mock('./lib/api', () => ({
   fetchRecommendations,
+  fetchRecommend,
   fetchCrops,
   postRefresh,
   fetchRefreshStatus,
@@ -70,6 +75,7 @@ const resetSpies = () => {
   loadFavorites.mockClear()
   saveFavorites.mockClear()
   fetchRecommendations.mockReset()
+  fetchRecommend.mockReset()
   fetchCrops.mockReset()
   postRefresh.mockReset()
   fetchRefreshStatus.mockReset()


### PR DESCRIPTION
## Summary
- replace the redundant fetchRecommendations mock with a dedicated fetchRecommend helper in the main test suite
- expose fetchRecommend from the API mock and ensure it is reset between test runs

## Testing
- `npm test -- src/main.test.tsx` *(fails: App.tsx duplicate symbol declarations reported by vite:esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd03e967c8321870713f8ff7a9a6d