### PR TITLE
Add growth days field to recommendation type

### DIFF
--- a/docs/spec/v0.1/TYPES.md
+++ b/docs/spec/v0.1/TYPES.md
@@ -34,6 +34,7 @@ export interface RecommendationItem {
   harvest_week: string
   sowing_week: string
   source: string
+  growth_days: number
 }
 ```
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,7 @@ export interface RecommendationItem {
   sowing_week: string
   harvest_week: string
   source: string
+  growth_days: number
 }
 
 export interface RecommendResponse {


### PR DESCRIPTION
## Summary
- add the growth_days field to the RecommendationItem interface used by the frontend
- mirror the new field in the public TypeScript type documentation

## Testing
- npm run typecheck *(fails: pre-existing TypeScript errors in src/App.tsx and src/main.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dcccee0cdc8321b512f2f370d97704