### PR TITLE
Fix RefreshResponse schema duplication

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -145,7 +145,7 @@ def price_series(
 
 def _start_refresh(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
     background_tasks.add_task(etl.start_etl_job)
-    return {"state": etl.STATE_RUNNING}
+    return schemas.RefreshResponse(state=etl.STATE_RUNNING)
 
 
 @app.post("/api/refresh", response_model=schemas.RefreshResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -27,10 +27,6 @@ class RecommendResponse(BaseModel):
     week: str
     region: Region
     items: list[RecommendationItem]
-
-
-class RefreshResponse(TypedDict):
-    state: Literal["success", "failure", "running", "stale"]
 
 
 class RecommendItem(RecommendationItem):


### PR DESCRIPTION
## Summary
- remove the duplicate TypedDict definition of RefreshResponse so only the BaseModel remains
- return a RefreshResponse model instance from the refresh endpoints to preserve typing

## Testing
- mypy backend/app/schemas.py
- pytest backend/tests/test_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68dcccecc5108321a625776d718dfc87