### PR TITLE
Define refresh trigger payload TypedDict for refresh endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -169,19 +169,28 @@ def price_series(
     )
 
 
-def _start_refresh(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
+def _start_refresh(
+    background_tasks: BackgroundTasks,
+    _payload: schemas.RefreshTriggerPayload | None = None,
+) -> schemas.RefreshResponse:
     background_tasks.add_task(etl.start_etl_job)
     return schemas.RefreshResponse(state=etl.STATE_RUNNING)
 
 
 @app.post("/api/refresh", response_model=schemas.RefreshResponse)
-def refresh(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
-    return _start_refresh(background_tasks)
+def refresh(
+    background_tasks: BackgroundTasks,
+    payload: schemas.RefreshTriggerPayload | None = None,
+) -> schemas.RefreshResponse:
+    return _start_refresh(background_tasks, payload)
 
 
 @app.post("/refresh", response_model=schemas.RefreshResponse)
-def refresh_legacy(background_tasks: BackgroundTasks) -> schemas.RefreshResponse:
-    return _start_refresh(background_tasks)
+def refresh_legacy(
+    background_tasks: BackgroundTasks,
+    payload: schemas.RefreshTriggerPayload | None = None,
+) -> schemas.RefreshResponse:
+    return _start_refresh(background_tasks, payload)
 
 
 def _refresh_status(conn: sqlite3.Connection) -> schemas.RefreshStatusResponse:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, NotRequired, TypedDict
 
 from pydantic import BaseModel
 
@@ -31,6 +31,12 @@ class RecommendResponse(BaseModel):
 
 class RecommendItem(RecommendationItem):
     """Backward compatible alias for recommendation items."""
+
+
+class RefreshTriggerPayload(TypedDict, total=False):
+    """Payload accepted by the refresh trigger endpoints."""
+
+    force: NotRequired[bool]
 
 
 class RefreshResponse(BaseModel):


### PR DESCRIPTION
## Summary
- add a RefreshTriggerPayload TypedDict so the refresh trigger request payload no longer conflicts with the RefreshResponse model
- update the refresh endpoints to thread the typed payload through the shared helper while keeping RefreshResponse as the sole response model

## Testing
- mypy backend/app/schemas.py
- pytest backend/tests/test_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd409d2908321ab4aedea03da253d