### PR TITLE
Document growth days field on recommendation items

### DIFF
--- a/docs/spec/v0.1/TYPES.md
+++ b/docs/spec/v0.1/TYPES.md
@@ -31,10 +31,10 @@ export interface GrowthDays {
 ```ts
 export interface RecommendationItem {
   crop: string
-  harvest_week: string
   sowing_week: string
+  harvest_week: string
   source: string
-  growth_days: number
+  growth_days: number // 播種から収穫までの推定日数
 }
 ```
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,7 @@ export interface RecommendationItem {
   sowing_week: string
   harvest_week: string
   source: string
+  /** 播種から収穫までの推定日数 */
   growth_days: number
 }
 


### PR DESCRIPTION
## Summary
- document the growth_days attribute on the RecommendationItem type used by the frontend
- align the public type specification with the runtime type and describe the growth_days field

## Testing
- npm run typecheck *(fails: existing TypeScript errors in src/App.tsx, src/hooks/useRecommendations.ts, and src/main.test.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd4090e1883219bb6f159495f7800