### PR TITLE
Streamline recommendation mocks for tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
 
-import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { FavStar, useFavorites } from './components/FavStar'
 import { PriceChart } from './components/PriceChart'
 import { RegionSelect } from './components/RegionSelect'
 import { fetchCrops, fetchRecommendations, fetchRefreshStatus, postRefresh } from './lib/api'
 import { compareIsoWeek, formatIsoWeek, getCurrentIsoWeek, normalizeIsoWeek } from './lib/week'
+import type { RecommendationRow } from './hooks/useRecommendations'
 import type { Crop, RecommendationItem, Region } from './types'
 
 import './App.css'
@@ -25,8 +26,7 @@ export const App = () => {
   const [selectedCropId, setSelectedCropId] = useState<number | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const { favorites, toggleFavorite, isFavorite } = useFavorites()
-  const { region, setRegion, queryWeek, setQueryWeek, currentWeek, displayWeek, sortedRows, handleSubmit } =
-    useRecommendations({ favorites })
+  const currentWeek = useMemo(() => getCurrentIsoWeek(), [])
 
   useEffect(() => {
     let active = true
@@ -77,6 +77,8 @@ export const App = () => {
       })
   }, [items, cropIndex, favorites])
 
+  const displayWeek = useMemo(() => formatIsoWeek(activeWeek), [activeWeek])
+
   const requestRecommendations = useCallback(
     async (targetRegion: Region, inputWeek: string, fallbackWeek: string) => {
       const normalizedWeek = normalizeIsoWeek(inputWeek, fallbackWeek)
@@ -113,6 +115,13 @@ export const App = () => {
   const handleRegionChange = useCallback((next: Region) => {
     setRegion(next)
   }, [])
+
+  const handleWeekChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setQueryWeek(event.target.value)
+    },
+    [setQueryWeek],
+  )
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true)

--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -53,7 +53,6 @@ const fetchRefreshStatus = vi.fn<() => Promise<RefreshStatusResponse>>()
 
 vi.mock('./lib/api', () => ({
   fetchRecommendations,
-  fetchRecommend,
   fetchCrops,
   postRefresh,
   fetchRefreshStatus,
@@ -67,7 +66,6 @@ const resetSpies = () => {
   loadFavorites.mockClear()
   saveFavorites.mockClear()
   fetchRecommendations.mockReset()
-  fetchRecommend.mockReset()
   fetchCrops.mockReset()
   postRefresh.mockReset()
   fetchRefreshStatus.mockReset()


### PR DESCRIPTION
## Summary
- remove the unused legacy `fetchRecommend` mock wiring in `main.test.tsx`
- restore `App`'s local state management after the hook refactor remnants and expose `handleWeekChange`
- derive `currentWeek` and `displayWeek` locally for rendering

## Testing
- npm test -- --runTestsByPath src/main.test.tsx *(fails: Vitest CLI does not support `--runTestsByPath`)*
- npm test -- src/main.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dcd40905548321adf0f837cd3889d1