### PR TITLE
Ensure recommendation API returns internal source metadata

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,14 +83,7 @@ def recommend(
         """
         SELECT
             c.name,
-            gd.days,
-            (
-                SELECT pw.source
-                FROM price_weekly AS pw
-                WHERE pw.crop_id = c.id AND pw.source != 'seed'
-                ORDER BY pw.week DESC
-                LIMIT 1
-            ) AS source
+            gd.days
         FROM crops AS c
         INNER JOIN growth_days AS gd ON gd.crop_id = c.id AND gd.region = ?
         ORDER BY c.name
@@ -102,14 +95,13 @@ def recommend(
     for row in rows:
         growth_days = int(row["days"])
         sowing_week_iso = utils_week.subtract_days_to_iso_week(reference_week, growth_days)
-        source = str(row["source"]) if row["source"] else "internal"
         items.append(
             schemas.RecommendItem(
                 crop=str(row["name"]),
                 growth_days=growth_days,
                 harvest_week=reference_week,
                 sowing_week=sowing_week_iso,
-                source=source,
+                source="internal",
             )
         )
 

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -83,3 +83,16 @@ def test_recommend_allows_region_override() -> None:
 
     payload = response.json()
     _assert_items(payload, region="cold")
+
+
+def test_recommend_ignores_price_sources_for_metadata() -> None:
+    response = client.get("/api/recommend", params={"week": REFERENCE_WEEK})
+    assert response.status_code == 200
+
+    payload = response.json()
+    items = payload["items"]
+    assert isinstance(items, list)
+    assert items, "no recommendation items returned"
+
+    sources = {item["source"] for item in items}
+    assert sources == {"internal"}


### PR DESCRIPTION
## Summary
- ensure the recommendation query stops pulling price metadata sources
- always return the internal source for recommendation items
- add a regression test that confirms recommendation items ignore price sources

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd402bdac8321bc25b8b327489d15