### PR TITLE
Refactor recommendation hook structure

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,6 @@ export const App = () => {
   const [selectedCropId, setSelectedCropId] = useState<number | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const { favorites, toggleFavorite, isFavorite } = useFavorites()
-  const currentWeek = useMemo(() => getCurrentIsoWeek(), [])
 
   useEffect(() => {
     let active = true
@@ -60,9 +59,12 @@ export const App = () => {
   const sortedRows = useMemo<RecommendationRow[]>(() => {
     const favoriteSet = new Set(favorites)
     return items
-      .map((item) => ({
+      .map<RecommendationRow>((item) => ({
         ...item,
         cropId: cropIndex.get(item.crop),
+        rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
+        sowingWeekLabel: formatIsoWeek(item.sowing_week),
+        harvestWeekLabel: formatIsoWeek(item.harvest_week),
       }))
       .sort((a, b) => {
         const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
@@ -113,10 +115,6 @@ export const App = () => {
     void requestRecommendations(region, queryWeek, activeWeek)
   }
 
-  const handleWeekChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setQueryWeek(event.currentTarget.value)
-  }, [])
-
   const handleRegionChange = useCallback((next: Region) => {
     setRegion(next)
   }, [])
@@ -152,8 +150,6 @@ export const App = () => {
       setRefreshing(false)
     }
   }, [])
-
-  const displayWeek = useMemo(() => formatIsoWeek(activeWeek), [activeWeek])
 
   return (
     <div className="app">
@@ -200,7 +196,7 @@ export const App = () => {
                 const isSelected = item.cropId !== undefined && item.cropId === selectedCropId
                 return (
                   <tr
-                    key={`${item.crop}-${item.sowing_week}-${item.harvest_week}`}
+                    key={item.rowKey}
                     className={`recommend__row${isSelected ? ' recommend__row--selected' : ''}`}
                     onClick={() => setSelectedCropId(item.cropId ?? null)}
                   >
@@ -214,8 +210,8 @@ export const App = () => {
                       <span>{item.crop}</span>
                     </div>
                   </td>
-                  <td>{formatIsoWeek(item.sowing_week)}</td>
-                  <td>{formatIsoWeek(item.harvest_week)}</td>
+                  <td>{item.sowingWeekLabel}</td>
+                  <td>{item.harvestWeekLabel}</td>
                   <td>{item.source}</td>
                 </tr>
                 )

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -3,51 +3,23 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 're
 import * as apiModule from '../lib/api'
 import * as weekModule from '../lib/week'
 import type { Crop, RecommendResponse, RecommendationItem, Region } from '../types'
+import {
+  DEFAULT_ACTIVE_WEEK,
+  DEFAULT_WEEK,
+  RecommendationRow,
+  buildRecommendationRows,
+  formatWeekLabel,
+  normalizeRecommendationResponse,
+} from '../utils/recommendations'
 
-const week = weekModule as typeof import('../lib/week') & {
-  currentIsoWeek?: () => string
-}
+const week = weekModule as typeof import('../lib/week')
 
 const api = apiModule as typeof import('../lib/api') & {
   fetchRecommend?: (input: { region: Region; week?: string }) => Promise<RecommendResponse>
 }
 
-const { compareIsoWeek, formatIsoWeek, normalizeIsoWeek } = week
+const { normalizeIsoWeek } = week
 const fetchCrops = api.fetchCrops
-
-const resolveCurrentWeek = (): string => {
-  let currentWeekFn: (() => string) | undefined
-  try {
-    currentWeekFn = week.getCurrentIsoWeek
-  } catch {
-    currentWeekFn = undefined
-  }
-  if (typeof currentWeekFn === 'function') {
-    return currentWeekFn()
-  }
-
-  let legacyWeekFn: (() => string) | undefined
-  try {
-    legacyWeekFn = week.currentIsoWeek
-  } catch {
-    legacyWeekFn = undefined
-  }
-  if (typeof legacyWeekFn === 'function') {
-    return legacyWeekFn()
-  }
-
-  return week.normalizeIsoWeek(undefined, '1970-W01')
-}
-
-const DEFAULT_WEEK = resolveCurrentWeek()
-const DEFAULT_ACTIVE_WEEK = normalizeIsoWeek(DEFAULT_WEEK)
-
-export type RecommendationRow = RecommendationItem & {
-  cropId?: number
-  rowKey: string
-  sowingWeekLabel: string
-  harvestWeekLabel: string
-}
 
 export interface UseRecommendationsOptions {
   favorites: readonly number[]
@@ -96,7 +68,7 @@ const useCropIndex = (): Map<string, number> => {
   }, [crops])
 }
 
-interface UseRecommendationLoaderResult {
+export interface UseRecommendationLoaderResult {
   queryWeek: string
   setQueryWeek: (week: string) => void
   activeWeek: string
@@ -105,7 +77,7 @@ interface UseRecommendationLoaderResult {
   requestRecommendations: (inputWeek: string, options?: { preferLegacy?: boolean }) => Promise<void>
 }
 
-const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult => {
+export const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult => {
   const [queryWeek, setQueryWeek] = useState(DEFAULT_WEEK)
   const [activeWeek, setActiveWeek] = useState(DEFAULT_ACTIVE_WEEK)
   const [items, setItems] = useState<RecommendationItem[]>([])
@@ -151,14 +123,12 @@ const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult 
             response = await callLegacy()
           }
         }
-        const resolvedWeek = normalizeIsoWeek(response.week, normalizedWeek)
-        const normalizedItems = response.items.map((item) => ({
-          ...item,
-          sowing_week: normalizeIsoWeek(item.sowing_week),
-          harvest_week: normalizeIsoWeek(item.harvest_week),
-        }))
+        const { week: responseWeek, items: normalizedItems } = normalizeRecommendationResponse(
+          response,
+          normalizedWeek,
+        )
         setItems(normalizedItems)
-        setActiveWeek(resolvedWeek)
+        setActiveWeek(responseWeek)
       } catch {
         setItems([])
       }
@@ -191,27 +161,7 @@ export const useRecommendations = ({ favorites }: UseRecommendationsOptions): Us
     useRecommendationLoader(region)
 
   const sortedRows = useMemo<RecommendationRow[]>(() => {
-    const favoriteSet = new Set(favorites)
-    return items
-      .map<RecommendationRow>((item) => ({
-        ...item,
-        cropId: cropIndex.get(item.crop),
-        rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
-        sowingWeekLabel: formatIsoWeek(item.sowing_week),
-        harvestWeekLabel: formatIsoWeek(item.harvest_week),
-      }))
-      .sort((a, b) => {
-        const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
-        const bFav = b.cropId !== undefined && favoriteSet.has(b.cropId) ? 1 : 0
-        if (aFav !== bFav) {
-          return bFav - aFav
-        }
-        const weekDiff = compareIsoWeek(a.sowing_week, b.sowing_week)
-        if (weekDiff !== 0) {
-          return weekDiff
-        }
-        return a.crop.localeCompare(b.crop, 'ja')
-      })
+    return buildRecommendationRows({ items, favorites, cropIndex })
   }, [items, cropIndex, favorites])
 
   const handleSubmit = useCallback(
@@ -222,7 +172,7 @@ export const useRecommendations = ({ favorites }: UseRecommendationsOptions): Us
     [queryWeek, requestRecommendations],
   )
 
-  const displayWeek = useMemo(() => formatIsoWeek(activeWeek), [activeWeek])
+  const displayWeek = useMemo(() => formatWeekLabel(activeWeek), [activeWeek])
 
   return {
     region,
@@ -236,4 +186,4 @@ export const useRecommendations = ({ favorites }: UseRecommendationsOptions): Us
   }
 }
 
-export type { UseRecommendationsOptions, UseRecommendationsResult }
+export type { RecommendationRow } from '../utils/recommendations'

--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -47,9 +47,6 @@ vi.mock('./lib/storage', () => ({
 const fetchRecommendations = vi.fn<
   (region: Region, week?: string) => Promise<RecommendResponse>
 >()
-const fetchRecommend = vi.fn<
-  (input: { region: Region; week?: string }) => Promise<RecommendResponse>
->()
 const fetchCrops = vi.fn<() => Promise<Crop[]>>()
 const postRefresh = vi.fn<() => Promise<RefreshResponse>>()
 const fetchRefreshStatus = vi.fn<() => Promise<RefreshStatusResponse>>()

--- a/frontend/src/utils/recommendations.ts
+++ b/frontend/src/utils/recommendations.ts
@@ -1,0 +1,99 @@
+import * as weekModule from '../lib/week'
+import type { RecommendResponse, RecommendationItem } from '../types'
+
+const week = weekModule as typeof import('../lib/week') & {
+  currentIsoWeek?: () => string
+}
+
+const { compareIsoWeek, formatIsoWeek, normalizeIsoWeek } = week
+
+export type RecommendationRow = RecommendationItem & {
+  cropId?: number
+  rowKey: string
+  sowingWeekLabel: string
+  harvestWeekLabel: string
+}
+
+export const resolveCurrentWeek = (): string => {
+  let currentWeekFn: (() => string) | undefined
+  try {
+    currentWeekFn = week.getCurrentIsoWeek
+  } catch {
+    currentWeekFn = undefined
+  }
+  if (typeof currentWeekFn === 'function') {
+    return currentWeekFn()
+  }
+
+  let legacyWeekFn: (() => string) | undefined
+  try {
+    legacyWeekFn = week.currentIsoWeek
+  } catch {
+    legacyWeekFn = undefined
+  }
+  if (typeof legacyWeekFn === 'function') {
+    return legacyWeekFn()
+  }
+
+  return week.normalizeIsoWeek(undefined, '1970-W01')
+}
+
+export const DEFAULT_WEEK = resolveCurrentWeek()
+export const DEFAULT_ACTIVE_WEEK = normalizeIsoWeek(DEFAULT_WEEK)
+
+export interface NormalizeRecommendationResult {
+  week: string
+  items: RecommendationItem[]
+}
+
+export const normalizeRecommendationResponse = (
+  response: RecommendResponse,
+  fallbackWeek: string,
+): NormalizeRecommendationResult => {
+  const weekValue = normalizeIsoWeek(response.week, fallbackWeek)
+  const normalizedItems = response.items.map<RecommendationItem>((item) => ({
+    ...item,
+    sowing_week: normalizeIsoWeek(item.sowing_week),
+    harvest_week: normalizeIsoWeek(item.harvest_week),
+  }))
+  return {
+    week: weekValue,
+    items: normalizedItems,
+  }
+}
+
+interface BuildRecommendationRowsArgs {
+  items: RecommendationItem[]
+  favorites: readonly number[]
+  cropIndex: Map<string, number>
+}
+
+export const buildRecommendationRows = ({
+  items,
+  favorites,
+  cropIndex,
+}: BuildRecommendationRowsArgs): RecommendationRow[] => {
+  const favoriteSet = new Set(favorites)
+  return items
+    .map<RecommendationRow>((item) => ({
+      ...item,
+      cropId: cropIndex.get(item.crop),
+      rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
+      sowingWeekLabel: formatIsoWeek(item.sowing_week),
+      harvestWeekLabel: formatIsoWeek(item.harvest_week),
+    }))
+    .sort((a, b) => {
+      const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
+      const bFav = b.cropId !== undefined && favoriteSet.has(b.cropId) ? 1 : 0
+      if (aFav !== bFav) {
+        return bFav - aFav
+      }
+      const weekDiff = compareIsoWeek(a.sowing_week, b.sowing_week)
+      if (weekDiff !== 0) {
+        return weekDiff
+      }
+      return a.crop.localeCompare(b.crop, 'ja')
+    })
+}
+
+export const formatWeekLabel = (value: string): string => formatIsoWeek(value)


### PR DESCRIPTION
## Summary
- extract recommendation week normalization and row-building helpers into a shared utility module
- expose the recommendation loader hook and simplify `useRecommendations` to focus on view state and handlers
- update legacy app/test code to consume the enriched recommendation rows returned by the hook

## Testing
- npm run lint
- npm run typecheck
- npm test -- --runTestsByPath src/main.test.tsx *(fails: Vitest does not support this flag; ran npm test -- src/main.test.tsx instead)*
- npm test -- src/main.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd30c469b88321bf9e3706779573cd