### PR TITLE
Adjust typing imports for schemas

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal
+from typing_extensions import NotRequired, TypedDict
 
 from pydantic import BaseModel
 


### PR DESCRIPTION
## Summary
- import Literal from typing while using typing_extensions for TypedDict and NotRequired

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd37a830f88321be7e70083f04741f