### PR TITLE
Add week change handler and memoize week display

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,6 +111,12 @@ export const App = () => {
     void requestRecommendations(region, queryWeek, activeWeek)
   }, [requestRecommendations, region, queryWeek, activeWeek])
 
+  const handleWeekChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setQueryWeek(normalizeIsoWeek(event.target.value, currentWeekRef.current))
+  }, [])
+
+  const displayWeek = useMemo(() => formatIsoWeek(activeWeek), [activeWeek])
+
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     void requestRecommendations(region, queryWeek, activeWeek)


### PR DESCRIPTION
## Summary
- add a week input change handler that normalizes the value before updating the query state
- memoize the active week label so the UI keeps using the formatted week string

## Testing
- npm run typecheck *(fails: RecommendationRow is not exported from useRecommendations, fetchRecommend mock missing)*
- npm run test *(fails: mocking setup for PriceChart causes ReferenceError: fetchRecommend is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68dd37b4981c8321b70d4018a7f433c4