### PR TITLE
Re-export RecommendationRow type from useRecommendations hook

### DIFF
--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -185,3 +185,5 @@ export const useRecommendations = ({ favorites }: UseRecommendationsOptions): Us
     handleSubmit,
   }
 }
+
+export type { RecommendationRow } from '../utils/recommendations'


### PR DESCRIPTION
## Summary
- re-export the RecommendationRow type from the useRecommendations hook so consumers can import it via the hook module

## Testing
- npm run typecheck (fails: pre-existing TypeScript errors in src/App.tsx and src/main.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68dd37b33fd083219d373c83a69bc0b0