### PR TITLE
Fix ruff lint issues in backend schemas

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal
-from typing_extensions import NotRequired, TypedDict
+from typing import Literal, NotRequired
 
 from pydantic import BaseModel
+from typing_extensions import TypedDict
 
 Region = Literal["cold", "temperate", "warm"]
 RefreshState = Literal["success", "failure", "running", "stale"]


### PR DESCRIPTION
## Summary
- import `NotRequired` from the standard library typing module
- reorder backend schema imports to satisfy ruff import sorting

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68dd36a68ef883219696746e4fd7c400