### PR TITLE
Update refresh endpoint response documentation

### DIFF
--- a/docs/spec/v0.1/API_REFERENCE.md
+++ b/docs/spec/v0.1/API_REFERENCE.md
@@ -68,8 +68,10 @@
 * **レスポンス**
 
 ```json
-{ "status": "refresh started" }
+{ "state": "running" }
 ```
+
+  * `state`: 更新ジョブの最新状態（`running`/`success`/`failure`/`stale`）
 
 ---
 


### PR DESCRIPTION
## Summary
- update the POST /refresh endpoint response example to use the state field
- document the possible state values for refresh jobs

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68de0be4304c83218a5a0f3255cb1180