### PR TITLE
feat: surface refresh status messages in frontend

### DIFF
--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -242,4 +242,99 @@ describe('App', () => {
 
     expect(saveFavorites).toHaveBeenLastCalledWith([2, 1])
   })
+
+  it('更新ボタンでメッセージが表示され alert を使わない', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+      { id: 2, name: 'にんじん', category: 'root' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [
+        {
+          crop: '春菊',
+          harvest_week: '2024-W35',
+          sowing_week: '2024-W30',
+          source: 'local-db',
+          growth_days: 35,
+        },
+      ],
+    })
+
+    const { user } = await renderApp()
+
+    const refreshButton = screen.getByRole('button', { name: '更新' })
+    const main = screen.getByRole('main')
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined)
+
+    fetchRefreshStatus.mockResolvedValue({
+      state: 'success',
+      started_at: null,
+      finished_at: null,
+      updated_records: 1,
+      last_error: null,
+    })
+    let resolveRefresh: (() => void) | undefined
+    let rejectRefresh: (() => void) | undefined
+    postRefresh.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = () =>
+            resolve({
+              state: 'success',
+              started_at: null,
+              finished_at: null,
+              updated_records: 0,
+              last_error: null,
+            })
+        }),
+    )
+    postRefresh.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectRefresh = () => reject(new Error('network'))
+        }),
+    )
+
+    try {
+      await user.click(refreshButton)
+      expect(refreshButton).toBeDisabled()
+
+      resolveRefresh?.()
+
+      await expect(
+        waitFor(() => {
+          expect(
+            within(main).getByText('更新リクエストを受け付けました。自動ステータス更新は未実装です。'),
+          ).toBeInTheDocument()
+        }),
+      ).resolves.toBeUndefined()
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1600)
+      })
+
+      expect(fetchRefreshStatus).not.toHaveBeenCalled()
+      expect(alertSpy).not.toHaveBeenCalled()
+      await waitFor(() => expect(refreshButton).not.toBeDisabled())
+
+      await user.click(refreshButton)
+      expect(refreshButton).toBeDisabled()
+
+      rejectRefresh?.()
+
+      await expect(
+        waitFor(() => {
+          expect(
+            within(main).getByText('更新リクエストに失敗しました。自動ステータス更新は未実装です。'),
+          ).toBeInTheDocument()
+        }),
+      ).resolves.toBeUndefined()
+      expect(alertSpy).not.toHaveBeenCalled()
+      await waitFor(() => expect(refreshButton).not.toBeDisabled())
+    } finally {
+      alertSpy.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- render refresh status messages in the main panel using component state instead of polling
- manage success and failure outcomes without window.alert and keep the refresh button disabled while processing
- add coverage to ensure the update flow displays the expected messaging and avoids alert usage

## Testing
- npm test -- src/main.test.tsx
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de0be7c95c8321910683accc53ae3a