### PR TITLE
Implement weekly price ETL pipeline

### DIFF
--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import json
 import sqlite3
-from datetime import UTC, datetime
+import time
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from datetime import UTC, date, datetime
+from pathlib import Path
 from typing import Any, Final, cast
 
-from . import db, schemas
+from . import db, schemas, utils_week
 
 STATE_RUNNING: Final[schemas.RefreshState] = "running"
 STATE_SUCCESS: Final[schemas.RefreshState] = "success"
@@ -17,6 +22,12 @@ _STATE_LOOKUP: dict[str, schemas.RefreshState] = {
     STATE_FAILURE: STATE_FAILURE,
     STATE_STALE: STATE_STALE,
 }
+
+_DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+_DEFAULT_PRICE_SOURCE = _DATA_DIR / "price_weekly.sample.json"
+_UNIT_FACTORS: dict[str, float] = {"円/kg": 1.0, "円/100g": 10.0, "円/500g": 2.0, "円/g": 1000.0}
+
+DataLoader = Callable[[], Iterable[dict[str, Any]]]
 
 
 def _utc_now() -> str:
@@ -49,18 +60,100 @@ def _coerce_state(value: Any) -> schemas.RefreshState:
     return STATE_STALE
 
 
-def run_etl(conn: Any) -> int:
-    row = conn.execute("SELECT COUNT(*) FROM price_weekly").fetchone()
-    if row is None:
-        return 0
-    value = row[0]
+def load_price_feed(path: Path | None = None) -> list[dict[str, Any]]:
+    target = _DEFAULT_PRICE_SOURCE if path is None else path
+    if not target.exists():
+        return []
+    with target.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, list):
+        raise ValueError(f"Expected list payload in {target}")
+    return [dict(item) for item in payload]
+
+
+def _normalize_week(value: Any) -> str:
+    if isinstance(value, int):
+        return utils_week.iso_week_from_int(int(value))
+    if isinstance(value, str):
+        raw = value.strip()
+        try:
+            utils_week.iso_week_to_date_mid(raw)
+        except utils_week.WeekFormatError:
+            try:
+                parsed = date.fromisoformat(raw)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError(f"Unsupported week value: {value!r}") from exc
+            return utils_week.date_to_iso_week(parsed)
+        return raw
+    raise TypeError(f"Unsupported week value: {value!r}")
+
+
+def _scaled_number(value: Any, factor: float) -> float | None:
     if value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value) * factor
+    raise TypeError(f"Unsupported numeric value: {value!r}")
+
+
+def run_etl(conn: sqlite3.Connection, *, data_loader: DataLoader | None = None) -> int:
+    loader = load_price_feed if data_loader is None else data_loader
+    records = list(loader())
+    if not records:
         return 0
-    return int(value)
+
+    converted: list[tuple[int, str, float | None, float | None, str]] = []
+    for record in records:
+        unit_raw = str(record.get("unit", "円/kg")).strip()
+        factor = _UNIT_FACTORS.get(unit_raw)
+        if factor is None:
+            raise ValueError(f"Unsupported unit: {unit_raw}")
+        converted.append(
+            (
+                int(record["crop_id"]),
+                _normalize_week(record.get("week")),
+                _scaled_number(record.get("avg_price"), factor),
+                _scaled_number(record.get("stddev"), factor),
+                str(record.get("source", "external")),
+            )
+        )
+
+    converted.sort(key=lambda item: (item[0], utils_week.iso_week_to_date_mid(item[1])))
+    history: dict[int, list[float | None]] = defaultdict(list)
+    transformed: list[tuple[int, str, float | None, float | None, str, str]] = []
+    for crop_id, week_iso, avg_price, stddev, source in converted:
+        recent = [value for value in history[crop_id][-3:] if value is not None]
+        if avg_price is None and recent:
+            avg_price = sum(recent) / len(recent)
+        history[crop_id].append(avg_price)
+        transformed.append((crop_id, week_iso, avg_price, stddev, "円/kg", source))
+
+    conn.executemany(
+        """
+        INSERT INTO price_weekly (
+            crop_id, week, avg_price, stddev, unit, source
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(crop_id, week) DO UPDATE SET
+            avg_price = excluded.avg_price,
+            stddev = excluded.stddev,
+            unit = excluded.unit,
+            source = excluded.source
+        """,
+        transformed,
+    )
+    conn.commit()
+    return len(transformed)
 
 
-def start_etl_job() -> None:
-    conn = db.get_conn()
+def start_etl_job(
+    *,
+    data_loader: DataLoader | None = None,
+    conn_factory: Callable[[], sqlite3.Connection] | None = None,
+    max_retries: int = 3,
+    retry_delay: float = 0.1,
+) -> None:
+    factory = conn_factory if conn_factory is not None else db.get_conn
+    conn = factory()
     try:
         _ensure_schema(conn)
         started_at = _utc_now()
@@ -86,7 +179,17 @@ def start_etl_job() -> None:
         conn.commit()
 
         try:
-            updated_records = run_etl(conn)
+            attempt = 0
+            while True:
+                try:
+                    updated_records = run_etl(conn, data_loader=data_loader)
+                    break
+                except sqlite3.DatabaseError:
+                    attempt += 1
+                    if attempt >= max_retries:
+                        raise
+                    if retry_delay:
+                        time.sleep(retry_delay)
         except Exception as exc:  # pragma: no cover - defensive path
             finished_at = _utc_now()
             error_message = str(exc)

--- a/backend/tests/test_etl.py
+++ b/backend/tests/test_etl.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app import db, etl
+
+
+def _make_conn(path: Path | None = None) -> sqlite3.Connection:
+    if path is None:
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+    else:
+        conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _prepare_crops(conn: sqlite3.Connection) -> None:
+    conn.execute("INSERT INTO crops (id, name, category) VALUES (1, 'A', 'leaf')")
+    conn.execute("INSERT INTO crops (id, name, category) VALUES (2, 'B', 'root')")
+    conn.commit()
+
+
+def test_run_etl_transforms_and_upserts_weekly_prices() -> None:
+    conn = _make_conn()
+    try:
+        db.init_db(conn)
+        _prepare_crops(conn)
+        conn.execute(
+            "INSERT INTO price_weekly (crop_id, week, avg_price, stddev, unit, source)"
+            " VALUES (1, '2024-W01', 50.0, 5.0, '円/kg', 'seed')"
+        )
+        conn.commit()
+
+        records = [
+            {
+                "crop_id": 1,
+                "week": "2024-01-01",
+                "avg_price": 12,
+                "stddev": 0.8,
+                "unit": "円/100g",
+                "source": "market",
+            },
+            {
+                "crop_id": 1,
+                "week": "2024-W02",
+                "avg_price": None,
+                "stddev": None,
+                "unit": "円/kg",
+                "source": "market",
+            },
+            {
+                "crop_id": 1,
+                "week": "2024-01-15",
+                "avg_price": 13,
+                "stddev": 0.5,
+                "unit": "円/500g",
+                "source": "market",
+            },
+            {
+                "crop_id": 2,
+                "week": "2024-01-08",
+                "avg_price": None,
+                "stddev": None,
+                "unit": "円/kg",
+                "source": "market",
+            },
+            {
+                "crop_id": 2,
+                "week": "2024-01-15",
+                "avg_price": 25,
+                "stddev": 1.1,
+                "unit": "円/100g",
+                "source": "market",
+            },
+        ]
+
+        updated = etl.run_etl(conn, data_loader=lambda: records)
+        assert updated == len(records)
+
+        rows = [
+            (
+                row["crop_id"],
+                row["week"],
+                row["avg_price"],
+                row["stddev"],
+                row["unit"],
+                row["source"],
+            )
+            for row in conn.execute(
+                "SELECT crop_id, week, avg_price, stddev, unit, source"
+                " FROM price_weekly ORDER BY crop_id, week"
+            ).fetchall()
+        ]
+        assert rows == [
+            (1, "2024-W01", pytest.approx(120.0), pytest.approx(8.0), "円/kg", "market"),
+            (1, "2024-W02", pytest.approx(120.0), None, "円/kg", "market"),
+            (1, "2024-W03", pytest.approx(26.0), pytest.approx(1.0), "円/kg", "market"),
+            (2, "2024-W02", None, None, "円/kg", "market"),
+            (2, "2024-W03", pytest.approx(250.0), pytest.approx(11.0), "円/kg", "market"),
+        ]
+    finally:
+        conn.close()
+
+
+def test_start_etl_job_records_run_metadata(tmp_path: Path) -> None:
+    db_path = tmp_path / "etl.db"
+
+    def conn_factory() -> sqlite3.Connection:
+        conn = _make_conn(db_path)
+        return conn
+
+    with conn_factory() as conn:
+        db.init_db(conn)
+        _prepare_crops(conn)
+
+    payload = [
+        {
+            "crop_id": 1,
+            "week": "2024-01-01",
+            "avg_price": 10,
+            "stddev": 0.4,
+            "unit": "円/100g",
+            "source": "loader",
+        }
+    ]
+    attempts = {"count": 0}
+
+    def loader() -> list[dict[str, object]]:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise sqlite3.OperationalError("transient failure")
+        return payload
+
+    etl.start_etl_job(
+        data_loader=loader,
+        conn_factory=conn_factory,
+        max_retries=2,
+        retry_delay=0,
+    )
+
+    with conn_factory() as conn:
+        row = conn.execute(
+            "SELECT avg_price, unit, source FROM price_weekly"
+            " WHERE crop_id = 1 AND week = '2024-W01'"
+        ).fetchone()
+        assert (
+            row["avg_price"],
+            row["unit"],
+            row["source"],
+        ) == (pytest.approx(100.0), "円/kg", "loader")
+
+        run_row = conn.execute(
+            "SELECT state, updated_records, last_error FROM etl_runs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert run_row["state"] == "success"
+        assert run_row["updated_records"] == len(payload)
+        assert run_row["last_error"] is None
+
+    assert attempts["count"] == 2


### PR DESCRIPTION
## Summary
- add regression tests validating weekly price ETL behavior via temporary SQLite and injectable loaders
- implement ETL extraction, transformation, and loading with unit conversion, ISO week normalization, gap filling, and retrying upserts

## Testing
- `cd backend && pytest -q`
- `cd backend && ruff check app`
- `cd backend && mypy app`


------
https://chatgpt.com/codex/tasks/task_e_68de0be9498083219c2cac63de1bd03f