### PR TITLE
Add tests for crops listing endpoint

### DIFF
--- a/backend/tests/test_crops.py
+++ b/backend/tests/test_crops.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.seed import seed
+
+
+@pytest.fixture(scope="module")
+def seeded_client() -> Iterator[TestClient]:
+    seed()
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def test_list_crops_returns_seeded_data(seeded_client: TestClient) -> None:
+    response = seeded_client.get("/api/crops")
+
+    assert response.status_code == 200
+
+    body = response.json()
+    assert isinstance(body, list)
+    assert body, "seed should provide at least one crop"
+    for item in body:
+        assert isinstance(item, dict)
+        assert set(item) >= {"id", "name", "category"}
+
+
+def test_list_crops_method_not_allowed(seeded_client: TestClient) -> None:
+    response = seeded_client.post("/api/crops")
+
+    assert response.status_code == 405


### PR DESCRIPTION
## Summary
- add backend test covering successful /api/crops response structure
- verify POST to /api/crops is rejected with 405 using seeded client fixture

## Testing
- cd backend && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de0be522dc8321afe72bd08be23632