### PR TITLE
Refactor ETL job orchestration

### DIFF
--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -2,62 +2,27 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import time
 from collections import defaultdict
 from collections.abc import Callable, Iterable
-from datetime import UTC, date, datetime
+from datetime import date
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Any
 
-from . import db, schemas, utils_week
+from . import etl_runner as _etl_runner
+from . import utils_week
 
-STATE_RUNNING: Final[schemas.RefreshState] = "running"
-STATE_SUCCESS: Final[schemas.RefreshState] = "success"
-STATE_FAILURE: Final[schemas.RefreshState] = "failure"
-STATE_STALE: Final[schemas.RefreshState] = "stale"
-
-_STATE_LOOKUP: dict[str, schemas.RefreshState] = {
-    STATE_RUNNING: STATE_RUNNING,
-    STATE_SUCCESS: STATE_SUCCESS,
-    STATE_FAILURE: STATE_FAILURE,
-    STATE_STALE: STATE_STALE,
-}
+STATE_FAILURE = _etl_runner.STATE_FAILURE
+STATE_RUNNING = _etl_runner.STATE_RUNNING
+STATE_STALE = _etl_runner.STATE_STALE
+STATE_SUCCESS = _etl_runner.STATE_SUCCESS
+start_etl_job = _etl_runner.start_etl_job
+get_last_status = _etl_runner.get_last_status
 
 _DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 _DEFAULT_PRICE_SOURCE = _DATA_DIR / "price_weekly.sample.json"
 _UNIT_FACTORS: dict[str, float] = {"円/kg": 1.0, "円/100g": 10.0, "円/500g": 2.0, "円/g": 1000.0}
 
 DataLoader = Callable[[], Iterable[dict[str, Any]]]
-
-
-def _utc_now() -> str:
-    return datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def _ensure_schema(conn: sqlite3.Connection) -> None:
-    columns = {row[1] for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()}
-    migrations: dict[str, str] = {
-        "state": "ALTER TABLE etl_runs ADD COLUMN state TEXT",
-        "started_at": "ALTER TABLE etl_runs ADD COLUMN started_at TEXT",
-        "finished_at": "ALTER TABLE etl_runs ADD COLUMN finished_at TEXT",
-        "last_error": "ALTER TABLE etl_runs ADD COLUMN last_error TEXT",
-    }
-    mutated = False
-    for column, ddl in migrations.items():
-        if column not in columns:
-            conn.execute(ddl)
-            mutated = True
-    if mutated:
-        conn.commit()
-
-
-def _coerce_state(value: Any) -> schemas.RefreshState:
-    if isinstance(value, str):
-        normalized = value.lower()
-        state = _STATE_LOOKUP.get(normalized)
-        if state is not None:
-            return state
-    return STATE_STALE
 
 
 def load_price_feed(path: Path | None = None) -> list[dict[str, Any]]:
@@ -145,121 +110,3 @@ def run_etl(conn: sqlite3.Connection, *, data_loader: DataLoader | None = None) 
     return len(transformed)
 
 
-def start_etl_job(
-    *,
-    data_loader: DataLoader | None = None,
-    conn_factory: Callable[[], sqlite3.Connection] | None = None,
-    max_retries: int = 3,
-    retry_delay: float = 0.1,
-) -> None:
-    factory = conn_factory if conn_factory is not None else db.get_conn
-    conn = factory()
-    try:
-        _ensure_schema(conn)
-        started_at = _utc_now()
-        cursor = conn.execute(
-            """
-            INSERT INTO etl_runs (
-                run_at,
-                status,
-                updated_records,
-                error_message,
-                state,
-                started_at,
-                finished_at,
-                last_error
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (started_at, STATE_RUNNING, 0, None, STATE_RUNNING, started_at, None, None),
-        )
-        run_id_raw = cursor.lastrowid
-        if run_id_raw is None:  # pragma: no cover - SQLite guarantees an id for AUTOINCREMENT
-            raise RuntimeError("Failed to persist ETL run metadata")
-        run_id = int(run_id_raw)
-        conn.commit()
-
-        try:
-            attempt = 0
-            while True:
-                try:
-                    updated_records = run_etl(conn, data_loader=data_loader)
-                    break
-                except sqlite3.DatabaseError:
-                    attempt += 1
-                    if attempt >= max_retries:
-                        raise
-                    if retry_delay:
-                        time.sleep(retry_delay)
-        except Exception as exc:  # pragma: no cover - defensive path
-            finished_at = _utc_now()
-            error_message = str(exc)
-            conn.execute(
-                """
-                UPDATE etl_runs
-                SET status = ?,
-                    state = ?,
-                    finished_at = ?,
-                    last_error = ?,
-                    error_message = ?
-                WHERE id = ?
-                """,
-                (STATE_FAILURE, STATE_FAILURE, finished_at, error_message, error_message, run_id),
-            )
-            conn.commit()
-            raise
-        else:
-            finished_at = _utc_now()
-            conn.execute(
-                """
-                UPDATE etl_runs
-                SET status = ?,
-                    state = ?,
-                    finished_at = ?,
-                    updated_records = ?,
-                    last_error = NULL,
-                    error_message = NULL
-                WHERE id = ?
-                """,
-                (STATE_SUCCESS, STATE_SUCCESS, finished_at, updated_records, run_id),
-            )
-            conn.commit()
-    finally:
-        conn.close()
-
-
-def get_last_status(conn: sqlite3.Connection) -> schemas.RefreshStatus:
-    _ensure_schema(conn)
-    row = conn.execute(
-        """
-        SELECT
-            COALESCE(state, status) AS state,
-            COALESCE(started_at, run_at) AS started_at,
-            finished_at,
-            updated_records,
-            COALESCE(last_error, error_message) AS last_error,
-            run_at
-        FROM etl_runs
-        ORDER BY COALESCE(started_at, run_at) DESC
-        LIMIT 1
-        """,
-    ).fetchone()
-    if row is None:
-        return schemas.RefreshStatus(
-            state="stale",
-            started_at=None,
-            finished_at=None,
-            updated_records=0,
-            last_error=None,
-        )
-
-    state = _coerce_state(row["state"])
-    finished_at = cast(str | None, row["finished_at"])
-    raw_updated_records = cast(int | None, row["updated_records"])
-    updated_records = 0 if raw_updated_records is None else int(raw_updated_records)
-    return schemas.RefreshStatus(
-        state=state,
-        started_at=row["started_at"],
-        finished_at=finished_at,
-        updated_records=updated_records,
-        last_error=cast(str | None, row["last_error"]),
-    )

--- a/backend/app/etl_runner.py
+++ b/backend/app/etl_runner.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
+from typing import Any, Final, cast
+
+from . import db, schemas
+
+STATE_RUNNING: Final[schemas.RefreshState] = "running"
+STATE_SUCCESS: Final[schemas.RefreshState] = "success"
+STATE_FAILURE: Final[schemas.RefreshState] = "failure"
+STATE_STALE: Final[schemas.RefreshState] = "stale"
+
+_STATE_LOOKUP: dict[str, schemas.RefreshState] = {
+    STATE_RUNNING: STATE_RUNNING,
+    STATE_SUCCESS: STATE_SUCCESS,
+    STATE_FAILURE: STATE_FAILURE,
+    STATE_STALE: STATE_STALE,
+}
+
+DataLoader = Callable[[], Iterable[dict[str, Any]]]
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    columns = {row[1] for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()}
+    migrations: dict[str, str] = {
+        "state": "ALTER TABLE etl_runs ADD COLUMN state TEXT",
+        "started_at": "ALTER TABLE etl_runs ADD COLUMN started_at TEXT",
+        "finished_at": "ALTER TABLE etl_runs ADD COLUMN finished_at TEXT",
+        "last_error": "ALTER TABLE etl_runs ADD COLUMN last_error TEXT",
+    }
+    mutated = False
+    for column, ddl in migrations.items():
+        if column not in columns:
+            conn.execute(ddl)
+            mutated = True
+    if mutated:
+        conn.commit()
+
+
+def _coerce_state(value: Any) -> schemas.RefreshState:
+    if isinstance(value, str):
+        normalized = value.lower()
+        state = _STATE_LOOKUP.get(normalized)
+        if state is not None:
+            return state
+    return STATE_STALE
+
+
+def start_etl_job(
+    *,
+    data_loader: DataLoader | None = None,
+    conn_factory: Callable[[], sqlite3.Connection] | None = None,
+    max_retries: int = 3,
+    retry_delay: float = 0.1,
+) -> None:
+    factory = conn_factory if conn_factory is not None else db.get_conn
+    conn = factory()
+    try:
+        _ensure_schema(conn)
+        started_at = _utc_now()
+        cursor = conn.execute(
+            """
+            INSERT INTO etl_runs (
+                run_at,
+                status,
+                updated_records,
+                error_message,
+                state,
+                started_at,
+                finished_at,
+                last_error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (started_at, STATE_RUNNING, 0, None, STATE_RUNNING, started_at, None, None),
+        )
+        run_id_raw = cursor.lastrowid
+        if run_id_raw is None:  # pragma: no cover - SQLite guarantees an id for AUTOINCREMENT
+            raise RuntimeError("Failed to persist ETL run metadata")
+        run_id = int(run_id_raw)
+        conn.commit()
+
+        try:
+            attempt = 0
+            while True:
+                try:
+                    from . import etl as _etl
+
+                    updated_records = _etl.run_etl(conn, data_loader=data_loader)
+                    break
+                except sqlite3.DatabaseError:
+                    attempt += 1
+                    if attempt >= max_retries:
+                        raise
+                    if retry_delay:
+                        time.sleep(retry_delay)
+        except Exception as exc:  # pragma: no cover - defensive path
+            finished_at = _utc_now()
+            error_message = str(exc)
+            conn.execute(
+                """
+                UPDATE etl_runs
+                SET status = ?,
+                    state = ?,
+                    finished_at = ?,
+                    last_error = ?,
+                    error_message = ?
+                WHERE id = ?
+                """,
+                (STATE_FAILURE, STATE_FAILURE, finished_at, error_message, error_message, run_id),
+            )
+            conn.commit()
+            raise
+        else:
+            finished_at = _utc_now()
+            conn.execute(
+                """
+                UPDATE etl_runs
+                SET status = ?,
+                    state = ?,
+                    finished_at = ?,
+                    updated_records = ?,
+                    last_error = NULL,
+                    error_message = NULL
+                WHERE id = ?
+                """,
+                (STATE_SUCCESS, STATE_SUCCESS, finished_at, updated_records, run_id),
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def get_last_status(conn: sqlite3.Connection) -> schemas.RefreshStatus:
+    _ensure_schema(conn)
+    row = conn.execute(
+        """
+        SELECT
+            COALESCE(state, status) AS state,
+            COALESCE(started_at, run_at) AS started_at,
+            finished_at,
+            updated_records,
+            COALESCE(last_error, error_message) AS last_error,
+            run_at
+        FROM etl_runs
+        ORDER BY COALESCE(started_at, run_at) DESC
+        LIMIT 1
+        """,
+    ).fetchone()
+    if row is None:
+        return schemas.RefreshStatus(
+            state="stale",
+            started_at=None,
+            finished_at=None,
+            updated_records=0,
+            last_error=None,
+        )
+
+    state = _coerce_state(row["state"])
+    finished_at = cast(str | None, row["finished_at"])
+    raw_updated_records = cast(int | None, row["updated_records"])
+    updated_records = 0 if raw_updated_records is None else int(raw_updated_records)
+    return schemas.RefreshStatus(
+        state=state,
+        started_at=row["started_at"],
+        finished_at=finished_at,
+        updated_records=updated_records,
+        last_error=cast(str | None, row["last_error"]),
+    )

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -4,18 +4,18 @@ import sqlite3
 
 from fastapi import BackgroundTasks
 
-from . import etl, schemas
+from . import etl_runner, schemas
 
 
 def start_refresh(
     background_tasks: BackgroundTasks,
     _payload: schemas.RefreshTriggerPayload | None = None,
 ) -> schemas.RefreshResponse:
-    background_tasks.add_task(etl.start_etl_job)
-    return schemas.RefreshResponse(state=etl.STATE_RUNNING)
+    background_tasks.add_task(etl_runner.start_etl_job)
+    return schemas.RefreshResponse(state=etl_runner.STATE_RUNNING)
 
 
 def refresh_status(conn: sqlite3.Connection) -> schemas.RefreshStatusResponse:
-    status = etl.get_last_status(conn)
+    status = etl_runner.get_last_status(conn)
     payload = status.model_dump() if hasattr(status, "model_dump") else status.dict()
     return schemas.RefreshStatusResponse(**payload)


### PR DESCRIPTION
## Summary
- add a dedicated `etl_runner` module to own schema management, status queries, and job orchestration helpers
- keep `etl.py` focused on transformation while re-exporting the public ETL job APIs for backwards compatibility
- update services to invoke the new runner module for refresh scheduling and status reporting

## Testing
- `cd backend && pytest -q`
- `cd backend && ruff check app`
- `cd backend && mypy app`


------
https://chatgpt.com/codex/tasks/task_e_68de491cf92483218d399a73833aa96c