### PR TITLE
Load initial region from storage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { FavStar, useFavorites } from './components/FavStar'
 import { PriceChart } from './components/PriceChart'
 import { RegionSelect } from './components/RegionSelect'
 import { fetchCrops, fetchRecommendations, postRefresh } from './lib/api'
+import { loadRegion } from './lib/storage'
 import { compareIsoWeek, formatIsoWeek, getCurrentIsoWeek, normalizeIsoWeek } from './lib/week'
 import type { RecommendationRow } from './hooks/useRecommendations'
 import type { Crop, RecommendationItem, Region } from './types'
@@ -19,7 +20,7 @@ const REGION_LABEL: Record<Region, string> = {
 
 export const App = () => {
   const currentWeekRef = useRef(getCurrentIsoWeek())
-  const [region, setRegion] = useState<Region>('temperate')
+  const [region, setRegion] = useState<Region>(() => loadRegion())
   const [queryWeek, setQueryWeek] = useState(currentWeekRef.current)
   const [activeWeek, setActiveWeek] = useState(() => normalizeIsoWeek(getCurrentIsoWeek()))
   const [items, setItems] = useState<RecommendationItem[]>([])

--- a/frontend/src/app.behavior.test.tsx
+++ b/frontend/src/app.behavior.test.tsx
@@ -22,6 +22,23 @@ describe('App behavior', () => {
     cleanup()
   })
 
+  it('保存済み地域で初回フェッチされる', async () => {
+    storageState.region = 'cold'
+
+    fetchCrops.mockResolvedValue([])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'cold',
+      items: [],
+    })
+
+    await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenNthCalledWith(1, 'cold', '2024-W30')
+    })
+  })
+
   it('地域選択と週入力でAPIが手動フェッチされる', async () => {
     fetchCrops.mockResolvedValue([
       { id: 1, name: '春菊', category: 'leaf' },


### PR DESCRIPTION
## Summary
- add a regression test ensuring the first recommendation fetch uses the persisted region
- initialize the app region state from local storage so the initial fetch honors persisted settings

## Testing
- cd frontend && npm test
- cd frontend && npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de66f9ea448321ac5eadf104087efa