### PR TITLE
Validate price week query parameters

### DIFF
--- a/backend/app/routes/price.py
+++ b/backend/app/routes/price.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
-from .. import schemas
+from .. import schemas, utils_week
 from ..dependencies import ConnDependency, FromWeekQuery, PriceCropQuery, ToWeekQuery
 
 router = APIRouter(prefix="/api/price")
@@ -22,6 +22,14 @@ def price_series(
     ).fetchone()
     if crop_row is None:
         raise HTTPException(status_code=404, detail="crop_not_found")
+
+    try:
+        if frm:
+            utils_week.iso_week_to_date_mid(frm)
+        if to:
+            utils_week.iso_week_to_date_mid(to)
+    except utils_week.WeekFormatError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     params: list[object] = [crop_id]
     cond = "WHERE crop_id = ?"

--- a/backend/tests/test_price.py
+++ b/backend/tests/test_price.py
@@ -14,3 +14,15 @@ def test_price_series_ok():
     assert body["crop_id"] == 1
     assert body["prices"]
     assert body["prices"][0]["week"].startswith("2025-W")
+
+
+def test_price_series_invalid_from_week():
+    r = client.get("/api/price", params={"crop_id": 1, "frm": "invalid", "to": "2025-W42"})
+    assert r.status_code == 400
+    assert r.json()["detail"] == "week must be in ISO format YYYY-Www"
+
+
+def test_price_series_invalid_to_week():
+    r = client.get("/api/price", params={"crop_id": 1, "frm": "2025-W40", "to": "2024-13"})
+    assert r.status_code == 400
+    assert r.json()["detail"] == "week must be in ISO format YYYY-Www"


### PR DESCRIPTION
## Summary
- add tests ensuring the price endpoint rejects non-ISO week parameters
- validate `frm`/`to` weeks with `iso_week_to_date_mid` and return HTTP 400 on invalid input

## Testing
- pytest -q
- ruff check app
- mypy app

------
https://chatgpt.com/codex/tasks/task_e_68de7165e7a083218ed0ba437c1eff3e