### PR TITLE
Adjust refresh response typing to match backend

### DIFF
--- a/docs/spec/v0.1/TYPES.md
+++ b/docs/spec/v0.1/TYPES.md
@@ -57,10 +57,6 @@ export interface RecommendResponse {
 
 export interface RefreshResponse {
   state: "success" | "failure" | "running" | "stale"
-  started_at?: string | null
-  finished_at?: string | null
-  updated_records?: number
-  last_error?: string | null
 }
 
 export interface RefreshStatusResponse {
@@ -83,5 +79,25 @@ export interface FavoritesStorage {
 
 export interface RegionStorage {
   region: Region
+}
+```
+
+---
+
+## 価格関連
+
+```ts
+export interface PricePoint {
+  week: string
+  avg_price: number | null
+  stddev: number | null
+}
+
+export interface PriceSeries {
+  crop_id: number
+  crop: string
+  unit: string
+  source: string
+  prices: PricePoint[]
 }
 ```

--- a/frontend/src/app.refresh.test.tsx
+++ b/frontend/src/app.refresh.test.tsx
@@ -60,10 +60,6 @@ describe('App refresh', () => {
           resolveRefresh = () =>
             resolve({
               state: 'success',
-              started_at: null,
-              finished_at: null,
-              updated_records: 0,
-              last_error: null,
             })
         }),
     )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -23,10 +23,6 @@ export interface RecommendResponse {
 
 export interface RefreshResponse {
   state: 'success' | 'failure' | 'running' | 'stale'
-  started_at?: string | null
-  finished_at?: string | null
-  updated_records?: number
-  last_error?: string | null
 }
 
 export interface RefreshStatusResponse {


### PR DESCRIPTION
## Summary
- update the refresh trigger test to rely only on the response state
- narrow the RefreshResponse TypeScript definition and align the spec documentation, adding price series types

## Testing
- npm run typecheck
- npm test -- --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68de7163817c8321bccaaf209136e27d