### PR TITLE
Update frontend build pipeline to reuse typecheck script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npm run typecheck && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.json src --ext .ts,.tsx,.js,.jsx",


### PR DESCRIPTION
## Summary
- update the frontend build script to reuse the existing typecheck command before running the Vite build

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7e8a72688321863b1e4527b81339