### PR TITLE
Refactor App to use recommendation hook and split UI components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,13 @@
+import { ChangeEvent, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
-import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-
-import { FavStar, useFavorites } from './components/FavStar'
+import { useFavorites } from './components/FavStar'
 import { PriceChart } from './components/PriceChart'
-import { RegionSelect } from './components/RegionSelect'
-import { fetchCrops, fetchRecommendations, postRefresh } from './lib/api'
+import { RefreshControls, RefreshMessage, RecommendationTable } from './components/Recommendations'
+import { useRecommendations } from './hooks/useRecommendations'
+import { postRefresh } from './lib/api'
 import { loadRegion } from './lib/storage'
-import { compareIsoWeek, formatIsoWeek, getCurrentIsoWeek, normalizeIsoWeek } from './lib/week'
-import type { RecommendationRow } from './hooks/useRecommendations'
-import type { Crop, RecommendationItem, Region } from './types'
+import { normalizeIsoWeek } from './lib/week'
+import type { Region } from './types'
 
 import './App.css'
 
@@ -19,115 +18,33 @@ const REGION_LABEL: Record<Region, string> = {
 }
 
 export const App = () => {
-  const currentWeekRef = useRef(getCurrentIsoWeek())
-  const [region, setRegion] = useState<Region>(() => loadRegion())
-  const [queryWeek, setQueryWeek] = useState(currentWeekRef.current)
-  const [activeWeek, setActiveWeek] = useState(() => normalizeIsoWeek(getCurrentIsoWeek()))
-  const [items, setItems] = useState<RecommendationItem[]>([])
-  const [crops, setCrops] = useState<Crop[]>([])
+  const { favorites, toggleFavorite, isFavorite } = useFavorites()
+  const { region, setRegion, queryWeek, setQueryWeek, currentWeek, displayWeek, sortedRows, handleSubmit } =
+    useRecommendations({ favorites })
   const [selectedCropId, setSelectedCropId] = useState<number | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [refreshMessage, setRefreshMessage] = useState<string | null>(null)
   const [refreshFailed, setRefreshFailed] = useState(false)
-  const { favorites, toggleFavorite, isFavorite } = useFavorites()
+  const initialRegionSet = useRef(false)
 
-  useEffect(() => {
-    let active = true
-    const load = async () => {
-      try {
-        const response = await fetchCrops()
-        if (active) {
-          setCrops(response)
-        }
-      } catch {
-        if (active) {
-          setCrops([])
-        }
-      }
+  useLayoutEffect(() => {
+    if (initialRegionSet.current) {
+      return
     }
-    void load()
-    return () => {
-      active = false
-    }
-  }, [])
+    initialRegionSet.current = true
+    setRegion(loadRegion())
+  }, [setRegion])
 
-  const cropIndex = useMemo(() => {
-    const map = new Map<string, number>()
-    crops.forEach((crop) => {
-      map.set(crop.name, crop.id)
-    })
-    return map
-  }, [crops])
-
-  const sortedRows = useMemo<RecommendationRow[]>(() => {
-    const favoriteSet = new Set(favorites)
-    return items
-      .map<RecommendationRow>((item) => {
-        const cropId = cropIndex.get(item.crop)
-        return {
-          ...item,
-          cropId,
-          rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
-          sowingWeekLabel: formatIsoWeek(item.sowing_week),
-          harvestWeekLabel: formatIsoWeek(item.harvest_week),
-        }
-      })
-      .sort((a, b) => {
-        const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
-        const bFav = b.cropId !== undefined && favoriteSet.has(b.cropId) ? 1 : 0
-        if (aFav !== bFav) {
-          return bFav - aFav
-        }
-        const weekDiff = compareIsoWeek(a.sowing_week, b.sowing_week)
-        if (weekDiff !== 0) {
-          return weekDiff
-        }
-        return a.crop.localeCompare(b.crop, 'ja')
-      })
-  }, [items, cropIndex, favorites])
-
-  const requestRecommendations = useCallback(
-    async (targetRegion: Region, inputWeek: string, fallbackWeek: string) => {
-      const normalizedWeek = normalizeIsoWeek(inputWeek, fallbackWeek)
-      setQueryWeek(normalizedWeek)
-      try {
-        const response = await fetchRecommendations(targetRegion, normalizedWeek)
-        const resolvedWeek = normalizeIsoWeek(response.week, normalizedWeek)
-        const normalizedItems = response.items.map((item) => ({
-          ...item,
-          sowing_week: normalizeIsoWeek(item.sowing_week),
-          harvest_week: normalizeIsoWeek(item.harvest_week),
-        }))
-        setItems(normalizedItems)
-        setActiveWeek(resolvedWeek)
-      } catch {
-        setItems([])
-      }
+  const handleWeekChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setQueryWeek(normalizeIsoWeek(event.target.value, currentWeek))
     },
-    [],
+    [setQueryWeek, currentWeek],
   )
-
-  const initialized = useRef(false)
-  useEffect(() => {
-    if (initialized.current) return
-    initialized.current = true
-    void requestRecommendations(region, queryWeek, activeWeek)
-  }, [requestRecommendations, region, queryWeek, activeWeek])
-
-  const handleWeekChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setQueryWeek(normalizeIsoWeek(event.target.value, currentWeekRef.current))
-  }, [])
-
-  const displayWeek = useMemo(() => formatIsoWeek(activeWeek), [activeWeek])
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    void requestRecommendations(region, queryWeek, activeWeek)
-  }
 
   const handleRegionChange = useCallback((next: Region) => {
     setRegion(next)
-  }, [])
+  }, [setRegion])
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true)
@@ -144,88 +61,41 @@ export const App = () => {
     }
   }, [])
 
+  const refreshSection = useMemo(() => {
+    if (!refreshMessage) {
+      return null
+    }
+    return <RefreshMessage message={refreshMessage} failed={refreshFailed} />
+  }, [refreshMessage, refreshFailed])
+
   return (
     <div className="app">
       <header className="app__header">
         <h1 className="app__title">Planting Planner</h1>
-        <form className="app__controls" onSubmit={handleSubmit}>
-          <RegionSelect onChange={handleRegionChange} />
-          <label className="app__week" htmlFor="week-input">
-            週
-            <input
-              id="week-input"
-              name="week"
-              type="text"
-              value={queryWeek}
-              onChange={handleWeekChange}
-              placeholder={currentWeekRef.current}
-              pattern="\d{4}-W\d{2}"
-              inputMode="numeric"
-            />
-          </label>
-          <button type="submit">この条件で見る</button>
-          <button className="app__refresh" type="button" onClick={() => void handleRefresh()} disabled={refreshing}>
-            更新
-          </button>
-        </form>
+        <RefreshControls
+          queryWeek={queryWeek}
+          currentWeek={currentWeek}
+          onWeekChange={handleWeekChange}
+          onSubmit={handleSubmit}
+          onRefresh={handleRefresh}
+          refreshing={refreshing}
+          onRegionChange={handleRegionChange}
+        />
       </header>
       <main className="app__main">
-        {refreshMessage && (
-          <div
-            className={`app__refresh-message${refreshFailed ? ' app__refresh-message--error' : ''}`}
-            role={refreshFailed ? 'alert' : 'status'}
-          >
-            {refreshMessage}
-          </div>
-        )}
+        {refreshSection}
         <section className="recommend">
           <div className="recommend__meta">
             <span>対象地域: {REGION_LABEL[region]}</span>
             <span>基準週: {displayWeek}</span>
           </div>
-          <table className="recommend__table">
-            <thead>
-              <tr>
-                <th scope="col">作物</th>
-                <th scope="col">播種週</th>
-                <th scope="col">収穫週</th>
-                <th scope="col">情報源</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedRows.map((item) => {
-                const isSelected = item.cropId !== undefined && item.cropId === selectedCropId
-                return (
-                  <tr
-                    key={item.rowKey}
-                    className={`recommend__row${isSelected ? ' recommend__row--selected' : ''}`}
-                    onClick={() => setSelectedCropId(item.cropId ?? null)}
-                  >
-                  <td>
-                    <div className="recommend__crop">
-                      <FavStar
-                        active={isFavorite(item.cropId)}
-                        cropName={item.crop}
-                        onToggle={() => toggleFavorite(item.cropId)}
-                      />
-                      <span>{item.crop}</span>
-                    </div>
-                  </td>
-                  <td>{item.sowingWeekLabel}</td>
-                  <td>{item.harvestWeekLabel}</td>
-                  <td>{item.source}</td>
-                </tr>
-                )
-              })}
-              {sortedRows.length === 0 && (
-                <tr>
-                  <td colSpan={4} className="recommend__empty">
-                    推奨データがありません
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+          <RecommendationTable
+            rows={sortedRows}
+            selectedCropId={selectedCropId}
+            onSelect={setSelectedCropId}
+            isFavorite={isFavorite}
+            toggleFavorite={toggleFavorite}
+          />
         </section>
         <section className="recommend__chart">
           <h2>価格推移</h2>

--- a/frontend/src/components/Recommendations.tsx
+++ b/frontend/src/components/Recommendations.tsx
@@ -1,0 +1,124 @@
+import { ChangeEvent, FormEvent } from 'react'
+
+import type { RecommendationRow, Region } from '../types'
+import { FavStar } from './FavStar'
+import { RegionSelect } from './RegionSelect'
+
+interface RefreshControlsProps {
+  queryWeek: string
+  currentWeek: string
+  onWeekChange: (event: ChangeEvent<HTMLInputElement>) => void
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onRefresh: () => Promise<void> | void
+  refreshing: boolean
+  onRegionChange: (region: Region) => void
+}
+
+export const RefreshControls = ({
+  queryWeek,
+  currentWeek,
+  onWeekChange,
+  onSubmit,
+  onRefresh,
+  refreshing,
+  onRegionChange,
+}: RefreshControlsProps) => {
+  return (
+    <form className="app__controls" onSubmit={onSubmit}>
+      <RegionSelect onChange={onRegionChange} />
+      <label className="app__week" htmlFor="week-input">
+        週
+        <input
+          id="week-input"
+          name="week"
+          type="text"
+          value={queryWeek}
+          onChange={onWeekChange}
+          placeholder={currentWeek}
+          pattern="\d{4}-W\d{2}"
+          inputMode="numeric"
+        />
+      </label>
+      <button type="submit">この条件で見る</button>
+      <button className="app__refresh" type="button" onClick={() => void onRefresh()} disabled={refreshing}>
+        更新
+      </button>
+    </form>
+  )
+}
+
+interface RefreshMessageProps {
+  message: string
+  failed: boolean
+}
+
+export const RefreshMessage = ({ message, failed }: RefreshMessageProps) => {
+  const className = `app__refresh-message${failed ? ' app__refresh-message--error' : ''}`
+  return (
+    <div className={className} role={failed ? 'alert' : 'status'}>
+      {message}
+    </div>
+  )
+}
+
+interface RecommendationTableProps {
+  rows: RecommendationRow[]
+  selectedCropId: number | null
+  onSelect: (cropId: number | null) => void
+  isFavorite: (cropId: number | undefined) => boolean
+  toggleFavorite: (cropId: number | undefined) => void
+}
+
+export const RecommendationTable = ({
+  rows,
+  selectedCropId,
+  onSelect,
+  isFavorite,
+  toggleFavorite,
+}: RecommendationTableProps) => {
+  return (
+    <table className="recommend__table">
+      <thead>
+        <tr>
+          <th scope="col">作物</th>
+          <th scope="col">播種週</th>
+          <th scope="col">収穫週</th>
+          <th scope="col">情報源</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((item) => {
+          const isSelected = item.cropId !== undefined && item.cropId === selectedCropId
+          return (
+            <tr
+              key={item.rowKey}
+              className={`recommend__row${isSelected ? ' recommend__row--selected' : ''}`}
+              onClick={() => onSelect(item.cropId ?? null)}
+            >
+              <td>
+                <div className="recommend__crop">
+                  <FavStar
+                    active={isFavorite(item.cropId)}
+                    cropName={item.crop}
+                    onToggle={() => toggleFavorite(item.cropId)}
+                  />
+                  <span>{item.crop}</span>
+                </div>
+              </td>
+              <td>{item.sowingWeekLabel}</td>
+              <td>{item.harvestWeekLabel}</td>
+              <td>{item.source}</td>
+            </tr>
+          )
+        })}
+        {rows.length === 0 && (
+          <tr>
+            <td colSpan={4} className="recommend__empty">
+              推奨データがありません
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  )
+}

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -2,6 +2,7 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 're
 
 import * as apiModule from '../lib/api'
 import * as weekModule from '../lib/week'
+import { loadRegion } from '../lib/storage'
 import type { Crop, RecommendResponse, RecommendationItem, Region } from '../types'
 import {
   DEFAULT_ACTIVE_WEEK,
@@ -141,7 +142,7 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
       return
     }
     initialFetchRef.current = true
-    void requestRecommendations(currentWeekRef.current, { preferLegacy: true })
+    void requestRecommendations(currentWeekRef.current)
   }, [requestRecommendations])
 
   return {
@@ -155,7 +156,7 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
 }
 
 export const useRecommendations = ({ favorites }: UseRecommendationsOptions): UseRecommendationsResult => {
-  const [region, setRegion] = useState<Region>('temperate')
+  const [region, setRegion] = useState<Region>(() => loadRegion())
   const cropIndex = useCropIndex()
   const { queryWeek, setQueryWeek, activeWeek, items, currentWeek, requestRecommendations } =
     useRecommendationLoader(region)


### PR DESCRIPTION
## Summary
- refactor App to rely on useRecommendations for data loading and formatting
- add reusable RefreshControls, RefreshMessage, and RecommendationTable components
- initialize recommendation hook with stored region and request modern API on load

## Testing
- npm test -- src/app.behavior.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de7e8cbd9c8321a25d7d5e0b224165