### PR TITLE
Refactor App to use recommendations hook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,14 @@
 
-import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChangeEvent, useCallback, useRef, useState } from 'react'
 
 import { FavStar, useFavorites } from './components/FavStar'
 import { PriceChart } from './components/PriceChart'
 import { RegionSelect } from './components/RegionSelect'
-import { fetchCrops, fetchRecommendations, postRefresh } from './lib/api'
+import { postRefresh } from './lib/api'
 import { loadRegion } from './lib/storage'
-import { compareIsoWeek, formatIsoWeek, getCurrentIsoWeek, normalizeIsoWeek } from './lib/week'
-import type { RecommendationRow } from './hooks/useRecommendations'
-import type { Crop, RecommendationItem, Region } from './types'
+import { normalizeIsoWeek } from './lib/week'
+import { useRecommendations } from './hooks/useRecommendations'
+import type { Region } from './types'
 
 import './App.css'
 
@@ -19,115 +19,30 @@ const REGION_LABEL: Record<Region, string> = {
 }
 
 export const App = () => {
-  const currentWeekRef = useRef(getCurrentIsoWeek())
-  const [region, setRegion] = useState<Region>(() => loadRegion())
-  const [queryWeek, setQueryWeek] = useState(currentWeekRef.current)
-  const [activeWeek, setActiveWeek] = useState(() => normalizeIsoWeek(getCurrentIsoWeek()))
-  const [items, setItems] = useState<RecommendationItem[]>([])
-  const [crops, setCrops] = useState<Crop[]>([])
   const [selectedCropId, setSelectedCropId] = useState<number | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [refreshMessage, setRefreshMessage] = useState<string | null>(null)
   const [refreshFailed, setRefreshFailed] = useState(false)
   const { favorites, toggleFavorite, isFavorite } = useFavorites()
 
-  useEffect(() => {
-    let active = true
-    const load = async () => {
-      try {
-        const response = await fetchCrops()
-        if (active) {
-          setCrops(response)
-        }
-      } catch {
-        if (active) {
-          setCrops([])
-        }
-      }
-    }
-    void load()
-    return () => {
-      active = false
-    }
-  }, [])
+  const initialRegionRef = useRef<Region>(loadRegion())
 
-  const cropIndex = useMemo(() => {
-    const map = new Map<string, number>()
-    crops.forEach((crop) => {
-      map.set(crop.name, crop.id)
-    })
-    return map
-  }, [crops])
+  const { region, setRegion, queryWeek, setQueryWeek, currentWeek, displayWeek, sortedRows, handleSubmit } =
+    useRecommendations({ favorites, initialRegion: initialRegionRef.current })
 
-  const sortedRows = useMemo<RecommendationRow[]>(() => {
-    const favoriteSet = new Set(favorites)
-    return items
-      .map<RecommendationRow>((item) => {
-        const cropId = cropIndex.get(item.crop)
-        return {
-          ...item,
-          cropId,
-          rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
-          sowingWeekLabel: formatIsoWeek(item.sowing_week),
-          harvestWeekLabel: formatIsoWeek(item.harvest_week),
-        }
-      })
-      .sort((a, b) => {
-        const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
-        const bFav = b.cropId !== undefined && favoriteSet.has(b.cropId) ? 1 : 0
-        if (aFav !== bFav) {
-          return bFav - aFav
-        }
-        const weekDiff = compareIsoWeek(a.sowing_week, b.sowing_week)
-        if (weekDiff !== 0) {
-          return weekDiff
-        }
-        return a.crop.localeCompare(b.crop, 'ja')
-      })
-  }, [items, cropIndex, favorites])
-
-  const requestRecommendations = useCallback(
-    async (targetRegion: Region, inputWeek: string, fallbackWeek: string) => {
-      const normalizedWeek = normalizeIsoWeek(inputWeek, fallbackWeek)
-      setQueryWeek(normalizedWeek)
-      try {
-        const response = await fetchRecommendations(targetRegion, normalizedWeek)
-        const resolvedWeek = normalizeIsoWeek(response.week, normalizedWeek)
-        const normalizedItems = response.items.map((item) => ({
-          ...item,
-          sowing_week: normalizeIsoWeek(item.sowing_week),
-          harvest_week: normalizeIsoWeek(item.harvest_week),
-        }))
-        setItems(normalizedItems)
-        setActiveWeek(resolvedWeek)
-      } catch {
-        setItems([])
-      }
+  const handleWeekChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setQueryWeek(normalizeIsoWeek(event.target.value, currentWeek))
     },
-    [],
+    [currentWeek, setQueryWeek],
   )
 
-  const initialized = useRef(false)
-  useEffect(() => {
-    if (initialized.current) return
-    initialized.current = true
-    void requestRecommendations(region, queryWeek, activeWeek)
-  }, [requestRecommendations, region, queryWeek, activeWeek])
-
-  const handleWeekChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setQueryWeek(normalizeIsoWeek(event.target.value, currentWeekRef.current))
-  }, [])
-
-  const displayWeek = useMemo(() => formatIsoWeek(activeWeek), [activeWeek])
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    void requestRecommendations(region, queryWeek, activeWeek)
-  }
-
-  const handleRegionChange = useCallback((next: Region) => {
-    setRegion(next)
-  }, [])
+  const handleRegionChange = useCallback(
+    (next: Region) => {
+      setRegion(next)
+    },
+    [setRegion],
+  )
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true)
@@ -158,7 +73,7 @@ export const App = () => {
               type="text"
               value={queryWeek}
               onChange={handleWeekChange}
-              placeholder={currentWeekRef.current}
+              placeholder={currentWeek}
               pattern="\d{4}-W\d{2}"
               inputMode="numeric"
             />

--- a/frontend/src/app.refresh.test.tsx
+++ b/frontend/src/app.refresh.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   fetchCrops,
+  fetchRecommend,
   fetchRefreshStatus,
   fetchRecommendations,
   postRefresh,
@@ -14,6 +15,7 @@ import {
 describe('App refresh', () => {
   beforeEach(() => {
     resetAppSpies()
+    fetchRecommend.mockRejectedValue(new Error('legacy endpoint disabled'))
   })
 
   afterEach(() => {

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -23,6 +23,7 @@ const fetchCrops = api.fetchCrops
 
 export interface UseRecommendationsOptions {
   favorites: readonly number[]
+  initialRegion?: Region
 }
 
 export interface UseRecommendationsResult {
@@ -154,11 +155,19 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
   }
 }
 
-export const useRecommendations = ({ favorites }: UseRecommendationsOptions): UseRecommendationsResult => {
-  const [region, setRegion] = useState<Region>('temperate')
+export const useRecommendations = ({ favorites, initialRegion }: UseRecommendationsOptions): UseRecommendationsResult => {
+  const initialRegionRef = useRef<Region>(initialRegion ?? 'temperate')
+  const [region, setRegion] = useState<Region>(initialRegionRef.current)
   const cropIndex = useCropIndex()
   const { queryWeek, setQueryWeek, activeWeek, items, currentWeek, requestRecommendations } =
     useRecommendationLoader(region)
+
+  useEffect(() => {
+    if (initialRegion !== undefined && initialRegion !== initialRegionRef.current) {
+      initialRegionRef.current = initialRegion
+      setRegion(initialRegion)
+    }
+  }, [initialRegion, setRegion])
 
   const sortedRows = useMemo<RecommendationRow[]>(() => {
     return buildRecommendationRows({ items, favorites, cropIndex })

--- a/frontend/tests/app.snapshot.test.tsx
+++ b/frontend/tests/app.snapshot.test.tsx
@@ -1,16 +1,26 @@
 import { cleanup, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+
+type UseRecommendationsModule = typeof import('../src/hooks/useRecommendations')
 
 import {
   fetchCrops,
+  fetchRecommend,
   fetchRecommendations,
   renderApp,
   resetAppSpies,
 } from './utils/renderApp'
 
 describe('App snapshot', () => {
-  beforeEach(() => {
+  let useRecommendationsModule: UseRecommendationsModule
+  let useRecommendationsSpy: MockInstance
+
+  beforeEach(async () => {
     resetAppSpies()
+    fetchRecommend.mockRejectedValue(new Error('legacy endpoint disabled'))
+    useRecommendationsModule = await import('../src/hooks/useRecommendations')
+    useRecommendationsSpy = vi.spyOn(useRecommendationsModule, 'useRecommendations')
     fetchCrops.mockResolvedValue([
       {
         id: 1,
@@ -46,6 +56,7 @@ describe('App snapshot', () => {
   })
 
   afterEach(() => {
+    useRecommendationsSpy.mockRestore()
     cleanup()
     resetAppSpies()
   })
@@ -60,5 +71,6 @@ describe('App snapshot', () => {
     const container = document.body.firstElementChild
     expect(container).not.toBeNull()
     expect(container).toMatchSnapshot()
+    expect(useRecommendationsSpy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- add regression coverage to ensure the App still routes through useRecommendations during behavior and snapshot tests
- refactor the App component to consume useRecommendations for fetching and formatting recommendation rows
- allow useRecommendations to accept the persisted region so initial loads hit the stored setting and align refresh tests with the new loader flow

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68de81c9b5408321b2273b11dd7924a8