### PR TITLE
Fix App recommendations hook usage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,20 +4,14 @@ import { ChangeEvent, useCallback, useRef, useState } from 'react'
 import { FavStar, useFavorites } from './components/FavStar'
 import { PriceChart } from './components/PriceChart'
 import { RegionSelect } from './components/RegionSelect'
+import { useRecommendations } from './hooks/useRecommendations'
 import * as api from './lib/api'
 import { loadRegion } from './lib/storage'
-import { compareIsoWeek, formatIsoWeek, getCurrentIsoWeek, normalizeIsoWeek } from './lib/week'
-import type { RecommendationRow } from './hooks/useRecommendations'
-import type { Crop, RecommendationItem, RecommendResponse, Region } from './types'
+import type { Region } from './types'
 
 import './App.css'
 
-const { fetchCrops, fetchRecommendations, postRefresh } = api
-const fetchRecommend = (
-  api as typeof api & {
-    fetchRecommend?: (input: { region: Region; week?: string }) => Promise<RecommendResponse>
-  }
-).fetchRecommend
+const { postRefresh } = api
 
 const REGION_LABEL: Record<Region, string> = {
   cold: '寒冷地',
@@ -37,77 +31,11 @@ export const App = () => {
   const { region, setRegion, queryWeek, setQueryWeek, currentWeek, displayWeek, sortedRows, handleSubmit } =
     useRecommendations({ favorites, initialRegion: initialRegionRef.current })
 
-  const sortedRows = useMemo<RecommendationRow[]>(() => {
-    const favoriteSet = new Set(favorites)
-    return items
-      .map<RecommendationRow>((item) => {
-        const cropId = cropIndex.get(item.crop)
-        return {
-          ...item,
-          cropId,
-          rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
-          sowingWeekLabel: formatIsoWeek(item.sowing_week),
-          harvestWeekLabel: formatIsoWeek(item.harvest_week),
-        }
-      })
-      .sort((a, b) => {
-        const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
-        const bFav = b.cropId !== undefined && favoriteSet.has(b.cropId) ? 1 : 0
-        if (aFav !== bFav) {
-          return bFav - aFav
-        }
-        const weekDiff = compareIsoWeek(a.sowing_week, b.sowing_week)
-        if (weekDiff !== 0) {
-          return weekDiff
-        }
-        return a.crop.localeCompare(b.crop, 'ja')
-      })
-  }, [items, cropIndex, favorites])
-
-  const requestRecommendations = useCallback(
-    async (targetRegion: Region, inputWeek: string, fallbackWeek: string) => {
-      const normalizedWeek = normalizeIsoWeek(inputWeek, fallbackWeek)
-      setQueryWeek(normalizedWeek)
-      const callModern = async () => {
-        if (typeof fetchRecommendations === 'function') {
-          return fetchRecommendations(targetRegion, normalizedWeek)
-        }
-        throw new Error('missing fetchRecommendations')
-      }
-      const callLegacy = async () => {
-        if (typeof fetchRecommend === 'function') {
-          return fetchRecommend({ region: targetRegion, week: normalizedWeek })
-        }
-        throw new Error('missing fetchRecommend')
-      }
-
-      try {
-        const response = await callModern()
-        const resolvedWeek = normalizeIsoWeek(response.week, normalizedWeek)
-        const normalizedItems = response.items.map((item) => ({
-          ...item,
-          sowing_week: normalizeIsoWeek(item.sowing_week),
-          harvest_week: normalizeIsoWeek(item.harvest_week),
-        }))
-        setItems(normalizedItems)
-        setActiveWeek(resolvedWeek)
-      } catch {
-        try {
-          const response = await callLegacy()
-          const resolvedWeek = normalizeIsoWeek(response.week, normalizedWeek)
-          const normalizedItems = response.items.map((item) => ({
-            ...item,
-            sowing_week: normalizeIsoWeek(item.sowing_week),
-            harvest_week: normalizeIsoWeek(item.harvest_week),
-          }))
-          setItems(normalizedItems)
-          setActiveWeek(resolvedWeek)
-        } catch {
-          setItems([])
-        }
-      }
+  const handleWeekChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setQueryWeek(event.currentTarget.value)
     },
-    [currentWeek, setQueryWeek],
+    [setQueryWeek],
   )
 
   const handleRegionChange = useCallback(

--- a/frontend/tests/app.interactions.test.tsx
+++ b/frontend/tests/app.interactions.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+import type { FormEvent } from 'react'
+
+import { resetAppSpies } from './utils/renderApp'
+
+type UseRecommendationsModule = typeof import('../src/hooks/useRecommendations')
+
+describe('App interactions', () => {
+  let useRecommendationsModule: UseRecommendationsModule
+  let useRecommendationsSpy: MockInstance
+
+  beforeEach(async () => {
+    resetAppSpies()
+    useRecommendationsModule = await import('../src/hooks/useRecommendations')
+    useRecommendationsSpy = vi.spyOn(useRecommendationsModule, 'useRecommendations')
+  })
+
+  afterEach(() => {
+    useRecommendationsSpy.mockRestore()
+    cleanup()
+    resetAppSpies()
+  })
+
+  test('週入力の変更で setQueryWeek が呼び出される', async () => {
+    const setQueryWeek = vi.fn()
+    const handleSubmit = vi.fn<(event: FormEvent<HTMLFormElement>) => void>((event) => {
+      event.preventDefault()
+    })
+
+    useRecommendationsSpy.mockReturnValue({
+      region: 'temperate',
+      setRegion: vi.fn(),
+      queryWeek: '2024-W30',
+      setQueryWeek,
+      currentWeek: '2024-W30',
+      displayWeek: '2024-W30',
+      sortedRows: [],
+      handleSubmit,
+    })
+
+    const App = (await import('../src/App')).default
+    render(<App />)
+
+    const weekInput = screen.getByLabelText('週') as HTMLInputElement
+    fireEvent.change(weekInput, { target: { value: '2024-W31' } })
+
+    expect(setQueryWeek).toHaveBeenLastCalledWith('2024-W31')
+  })
+})

--- a/frontend/tests/utils/renderApp.tsx
+++ b/frontend/tests/utils/renderApp.tsx
@@ -81,8 +81,8 @@ export const renderApp = async () => {
   const user = userEvent.setup()
   render(<App />)
   await waitFor(() => {
-    if (!fetchRecommendations.mock.calls.length) {
-      throw new Error('fetchRecommendations not called yet')
+    if (!fetchRecommendations.mock.calls.length && !fetchRecommend.mock.calls.length) {
+      throw new Error('recommendations not requested yet')
     }
   })
   return { user }


### PR DESCRIPTION
## Summary
- rely on the useRecommendations hook inside App for sorting and query week state
- add an interaction test to ensure week input changes call the hook setter
- update the renderApp helper to wait for either recommendations API mock

## Testing
- npm run typecheck
- npm test -- src/app.behavior.test.tsx
- npm test -- src/app.refresh.test.tsx
- npm test -- tests/app.snapshot.test.tsx
- npm test -- tests/app.interactions.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de88003ba88321be82669e86fd5125