### PR TITLE
Fix ESLint prefer-const warning in useRecommendations

### DIFF
--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -97,7 +97,6 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
       setQueryWeek(normalizedWeek)
       const preferLegacy = options?.preferLegacy ?? false
       try {
-        let response: RecommendResponse | undefined
         const callModern = async (): Promise<RecommendResponse | undefined> => {
           if (typeof api.fetchRecommendations !== 'function') {
             return undefined
@@ -122,7 +121,7 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
         const primary = preferLegacy ? callLegacy : callModern
         const secondary = preferLegacy ? callModern : callLegacy
 
-        response = (await primary()) ?? (await secondary())
+        const response = (await primary()) ?? (await secondary())
         if (!response) {
           setItems([])
           return


### PR DESCRIPTION
## Summary
- update useRecommendationLoader to use a const binding for the response value
- resolve the ESLint prefer-const warning raised by the lint script

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de8ee42a7883219a64d2563ee479ae