### PR TITLE
Fix mypy typing for ETL modules

### DIFF
--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from . import etl_runner as _etl_runner
 from . import utils_week
@@ -62,7 +62,10 @@ def _scaled_number(value: Any, factor: float) -> float | None:
 
 
 def run_etl(conn: sqlite3.Connection, *, data_loader: DataLoader | None = None) -> int:
-    loader = load_price_feed if data_loader is None else data_loader
+    if data_loader is None:
+        loader = cast(DataLoader, load_price_feed)
+    else:
+        loader = data_loader
     records = list(loader())
     if not records:
         return 0


### PR DESCRIPTION
## Summary
- add a protocol cast for the dynamically imported ETL module so that mypy can understand `run_etl`
- ensure the default loader in `run_etl` is typed as `DataLoader` when no custom loader is provided

## Testing
- `poetry run mypy` *(fails: Poetry configuration is invalid because name/version are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68de914636fc83218f16d7cc1f3e06f7