### PR TITLE
Fix mypy typing for ETL modules

### DIFF
--- a/backend/app/etl.py
+++ b/backend/app/etl.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from . import etl_runner as _etl_runner
 from . import utils_week
@@ -62,7 +62,10 @@ def _scaled_number(value: Any, factor: float) -> float | None:
 
 
 def run_etl(conn: sqlite3.Connection, *, data_loader: DataLoader | None = None) -> int:
-    loader = load_price_feed if data_loader is None else data_loader
+    if data_loader is None:
+        loader = cast(DataLoader, load_price_feed)
+    else:
+        loader = data_loader
     records = list(loader())
     if not records:
         return 0

--- a/backend/app/etl_runner.py
+++ b/backend/app/etl_runner.py
@@ -23,10 +23,14 @@ _STATE_LOOKUP: dict[str, schemas.RefreshState] = {
 DataLoader = Callable[[], Iterable[dict[str, Any]]]
 
 
-class _ETLModule(Protocol):
-    def run_etl(
+class _RunEtlFunc(Protocol):
+    def __call__(
         self, conn: sqlite3.Connection, *, data_loader: DataLoader | None = None
     ) -> int: ...
+
+
+class _ETLModule(Protocol):
+    run_etl: _RunEtlFunc
 
 
 def _utc_now() -> str:

--- a/backend/app/etl_runner.py
+++ b/backend/app/etl_runner.py
@@ -26,8 +26,7 @@ DataLoader = Callable[[], Iterable[dict[str, Any]]]
 class _ETLModule(Protocol):
     def run_etl(
         self, conn: sqlite3.Connection, *, data_loader: DataLoader | None = None
-    ) -> int:
-        ...
+    ) -> int: ...
 
 
 def _utc_now() -> str:
@@ -100,9 +99,7 @@ def start_etl_job(
                     from . import etl as _etl
 
                     etl_module = cast(_ETLModule, _etl)
-                    updated_records = etl_module.run_etl(
-                        conn, data_loader=data_loader
-                    )
+                    updated_records = etl_module.run_etl(conn, data_loader=data_loader)
                     break
                 except sqlite3.DatabaseError:
                     attempt += 1


### PR DESCRIPTION
## Summary
- add a protocol cast for the dynamically imported ETL module so that mypy can understand `run_etl`
- ensure the default loader in `run_etl` is typed as `DataLoader` when no custom loader is provided

## Testing
- `poetry run mypy` *(fails: Poetry configuration is invalid because name/version are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68de914636fc83218f16d7cc1f3e06f7