### PR TITLE
refactor: delegate week normalization to hook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import { PriceChart } from './components/PriceChart'
 import { RegionSelect } from './components/RegionSelect'
 import { postRefresh } from './lib/api'
 import { loadRegion } from './lib/storage'
-import { normalizeIsoWeek } from './lib/week'
 import { useRecommendations } from './hooks/useRecommendations'
 import type { Region } from './types'
 
@@ -32,7 +31,7 @@ export const App = () => {
 
   const handleWeekChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setQueryWeek(normalizeIsoWeek(event.target.value, currentWeek))
+      setQueryWeek(event.target.value)
     },
     [setQueryWeek],
   )

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -161,8 +161,15 @@ export const useRecommendations = ({ favorites, initialRegion }: UseRecommendati
   const initialRegionRef = useRef<Region>(initialRegion ?? 'temperate')
   const [region, setRegion] = useState<Region>(initialRegionRef.current)
   const cropIndex = useCropIndex()
-  const { queryWeek, setQueryWeek, activeWeek, items, currentWeek, requestRecommendations } =
+  const { queryWeek, setQueryWeek: setRawQueryWeek, activeWeek, items, currentWeek, requestRecommendations } =
     useRecommendationLoader(region)
+
+  const setQueryWeek = useCallback(
+    (nextWeek: string) => {
+      setRawQueryWeek(normalizeIsoWeek(nextWeek, currentWeek))
+    },
+    [currentWeek, setRawQueryWeek],
+  )
 
   useEffect(() => {
     if (initialRegion !== undefined && initialRegion !== initialRegionRef.current) {


### PR DESCRIPTION
## Summary
- normalize week input inside `useRecommendations` so callers can rely on the hook output
- simplify `App.tsx` week input handler to pass the raw value back to the hook

## Testing
- npm run lint
- npm run typecheck
- npm test -- --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68df08b19f8083219afc745331282991