### PR TITLE
Add fetchRecommend helper and tests for legacy recommend API

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RecommendResponse } from '../types'
+
+import { fetchRecommend } from './api'
+
+describe('fetchRecommend', () => {
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_ENDPOINT', '/api')
+    fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('request を通じて /recommend エンドポイントへ GET する', async () => {
+    const payload: RecommendResponse = {
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    }
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await fetchRecommend({ region: 'temperate', week: '2024-W30' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/recommend?region=temperate&week=2024-W30',
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )
+    expect(result).toEqual(payload)
+  })
+
+  it('レスポンスが失敗した場合は例外を送出する', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('internal error', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    )
+
+    await expect(fetchRecommend({ region: 'temperate' })).rejects.toThrow(
+      'internal error',
+    )
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,6 +51,21 @@ export const fetchRecommendations = async (
   return request<RecommendResponse>(url)
 }
 
+export const fetchRecommend = async ({
+  region,
+  week,
+}: {
+  region: Region
+  week?: string
+}): Promise<RecommendResponse> => {
+  const params = new URLSearchParams({ region })
+  if (week) {
+    params.set('week', week)
+  }
+  const url = buildUrl('/recommend', params)
+  return request<RecommendResponse>(url)
+}
+
 export const postRefresh = async (body?: unknown): Promise<RefreshResponse> => {
   const url = buildUrl('/refresh')
   const init: RequestInit = { method: 'POST' }


### PR DESCRIPTION
## Summary
- add fetchRecommend helper that reuses buildUrl/request to call the legacy recommend endpoint
- add unit coverage ensuring fetchRecommend handles successful and error responses via mocked fetch

## Testing
- npm run typecheck
- CI=1 npm run test

------
https://chatgpt.com/codex/tasks/task_e_68df105d9bc883218edb779373b64e75