### PR TITLE
Refactor app layout into components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,10 @@
 
 import { ChangeEvent, useCallback, useRef, useState } from 'react'
 
-import { FavStar, useFavorites } from './components/FavStar'
-import { PriceChart } from './components/PriceChart'
-import { RegionSelect } from './components/RegionSelect'
+import { PriceChartSection } from './components/PriceChartSection'
+import { RecommendationsTable } from './components/RecommendationsTable'
+import { SearchControls } from './components/SearchControls'
+import { useFavorites } from './components/FavStar'
 import { postRefresh } from './lib/api'
 import { loadRegion } from './lib/storage'
 import { normalizeIsoWeek } from './lib/week'
@@ -11,12 +12,6 @@ import { useRecommendations } from './hooks/useRecommendations'
 import type { Region } from './types'
 
 import './App.css'
-
-const REGION_LABEL: Record<Region, string> = {
-  cold: '寒冷地',
-  temperate: '温暖地',
-  warm: '暖地',
-}
 
 export const App = () => {
   const [selectedCropId, setSelectedCropId] = useState<number | null>(null)
@@ -63,26 +58,15 @@ export const App = () => {
     <div className="app">
       <header className="app__header">
         <h1 className="app__title">Planting Planner</h1>
-        <form className="app__controls" onSubmit={handleSubmit}>
-          <RegionSelect onChange={handleRegionChange} />
-          <label className="app__week" htmlFor="week-input">
-            週
-            <input
-              id="week-input"
-              name="week"
-              type="text"
-              value={queryWeek}
-              onChange={handleWeekChange}
-              placeholder={currentWeek}
-              pattern="\d{4}-W\d{2}"
-              inputMode="numeric"
-            />
-          </label>
-          <button type="submit">この条件で見る</button>
-          <button className="app__refresh" type="button" onClick={() => void handleRefresh()} disabled={refreshing}>
-            更新
-          </button>
-        </form>
+        <SearchControls
+          queryWeek={queryWeek}
+          currentWeek={currentWeek}
+          onWeekChange={handleWeekChange}
+          onRegionChange={handleRegionChange}
+          onSubmit={handleSubmit}
+          onRefresh={handleRefresh}
+          refreshing={refreshing}
+        />
       </header>
       <main className="app__main">
         {refreshMessage && (
@@ -93,60 +77,16 @@ export const App = () => {
             {refreshMessage}
           </div>
         )}
-        <section className="recommend">
-          <div className="recommend__meta">
-            <span>対象地域: {REGION_LABEL[region]}</span>
-            <span>基準週: {displayWeek}</span>
-          </div>
-          <table className="recommend__table">
-            <thead>
-              <tr>
-                <th scope="col">作物</th>
-                <th scope="col">播種週</th>
-                <th scope="col">収穫週</th>
-                <th scope="col">情報源</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedRows.map((item) => {
-                const isSelected = item.cropId !== undefined && item.cropId === selectedCropId
-                return (
-                  <tr
-                    key={item.rowKey}
-                    className={`recommend__row${isSelected ? ' recommend__row--selected' : ''}`}
-                    onClick={() => setSelectedCropId(item.cropId ?? null)}
-                  >
-                  <td>
-                    <div className="recommend__crop">
-                      <FavStar
-                        active={isFavorite(item.cropId)}
-                        cropName={item.crop}
-                        onToggle={() => toggleFavorite(item.cropId)}
-                      />
-                      <span>{item.crop}</span>
-                    </div>
-                  </td>
-                  <td>{item.sowingWeekLabel}</td>
-                  <td>{item.harvestWeekLabel}</td>
-                  <td>{item.source}</td>
-                </tr>
-                )
-              })}
-              {sortedRows.length === 0 && (
-                <tr>
-                  <td colSpan={4} className="recommend__empty">
-                    推奨データがありません
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </section>
-        <section className="recommend__chart">
-          <h2>価格推移</h2>
-          <PriceChart cropId={selectedCropId} range={{ from: undefined, to: undefined }} />
-          <p className="recommend__chart-hint">作物一覧で行をクリックすると、価格推移が表示されます。</p>
-        </section>
+        <RecommendationsTable
+          region={region}
+          displayWeek={displayWeek}
+          rows={sortedRows}
+          selectedCropId={selectedCropId}
+          onSelect={setSelectedCropId}
+          onToggleFavorite={toggleFavorite}
+          isFavorite={isFavorite}
+        />
+        <PriceChartSection selectedCropId={selectedCropId} />
       </main>
     </div>
   )

--- a/frontend/src/components/PriceChartSection.tsx
+++ b/frontend/src/components/PriceChartSection.tsx
@@ -1,0 +1,15 @@
+import { PriceChart } from './PriceChart'
+
+interface PriceChartSectionProps {
+  selectedCropId: number | null
+}
+
+export const PriceChartSection = ({ selectedCropId }: PriceChartSectionProps) => (
+  <section className="recommend__chart">
+    <h2>価格推移</h2>
+    <PriceChart cropId={selectedCropId} range={{ from: undefined, to: undefined }} />
+    <p className="recommend__chart-hint">作物一覧で行をクリックすると、価格推移が表示されます。</p>
+  </section>
+)
+
+PriceChartSection.displayName = 'PriceChartSection'

--- a/frontend/src/components/RecommendationsTable.tsx
+++ b/frontend/src/components/RecommendationsTable.tsx
@@ -1,0 +1,83 @@
+import { FavStar } from './FavStar'
+import type { RecommendationRow } from '../hooks/useRecommendations'
+import type { Region } from '../types'
+
+const REGION_LABEL: Record<Region, string> = {
+  cold: '寒冷地',
+  temperate: '温暖地',
+  warm: '暖地',
+}
+
+interface RecommendationsTableProps {
+  region: Region
+  displayWeek: string
+  rows: RecommendationRow[]
+  selectedCropId: number | null
+  onSelect: (cropId: number | null) => void
+  onToggleFavorite: (cropId?: number) => void
+  isFavorite: (cropId?: number) => boolean
+}
+
+export const RecommendationsTable = ({
+  region,
+  displayWeek,
+  rows,
+  selectedCropId,
+  onSelect,
+  onToggleFavorite,
+  isFavorite,
+}: RecommendationsTableProps) => {
+  return (
+    <section className="recommend">
+      <div className="recommend__meta">
+        <span>対象地域: {REGION_LABEL[region]}</span>
+        <span>基準週: {displayWeek}</span>
+      </div>
+      <table className="recommend__table">
+        <thead>
+          <tr>
+            <th scope="col">作物</th>
+            <th scope="col">播種週</th>
+            <th scope="col">収穫週</th>
+            <th scope="col">情報源</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((item) => {
+            const isSelected = item.cropId !== undefined && item.cropId === selectedCropId
+            return (
+              <tr
+                key={item.rowKey}
+                className={`recommend__row${isSelected ? ' recommend__row--selected' : ''}`}
+                onClick={() => onSelect(item.cropId ?? null)}
+              >
+                <td>
+                  <div className="recommend__crop">
+                    <FavStar
+                      active={isFavorite(item.cropId)}
+                      cropName={item.crop}
+                      onToggle={() => onToggleFavorite(item.cropId)}
+                    />
+                    <span>{item.crop}</span>
+                  </div>
+                </td>
+                <td>{item.sowingWeekLabel}</td>
+                <td>{item.harvestWeekLabel}</td>
+                <td>{item.source}</td>
+              </tr>
+            )
+          })}
+          {rows.length === 0 && (
+            <tr>
+              <td colSpan={4} className="recommend__empty">
+                推奨データがありません
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+RecommendationsTable.displayName = 'RecommendationsTable'

--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -1,0 +1,56 @@
+import type { ChangeEvent, FormEvent } from 'react'
+
+import { RegionSelect } from './RegionSelect'
+import type { Region } from '../types'
+
+interface SearchControlsProps {
+  queryWeek: string
+  currentWeek: string
+  onWeekChange: (event: ChangeEvent<HTMLInputElement>) => void
+  onRegionChange: (region: Region) => void
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onRefresh: () => void | Promise<void>
+  refreshing: boolean
+}
+
+export const SearchControls = ({
+  queryWeek,
+  currentWeek,
+  onWeekChange,
+  onRegionChange,
+  onSubmit,
+  onRefresh,
+  refreshing,
+}: SearchControlsProps) => {
+  return (
+    <form className="app__controls" onSubmit={onSubmit}>
+      <RegionSelect onChange={onRegionChange} />
+      <label className="app__week" htmlFor="week-input">
+        週
+        <input
+          id="week-input"
+          name="week"
+          type="text"
+          value={queryWeek}
+          onChange={onWeekChange}
+          placeholder={currentWeek}
+          pattern="\d{4}-W\d{2}"
+          inputMode="numeric"
+        />
+      </label>
+      <button type="submit">この条件で見る</button>
+      <button
+        className="app__refresh"
+        type="button"
+        onClick={() => {
+          void onRefresh()
+        }}
+        disabled={refreshing}
+      >
+        更新
+      </button>
+    </form>
+  )
+}
+
+SearchControls.displayName = 'SearchControls'

--- a/frontend/tests/app.interactions.test.tsx
+++ b/frontend/tests/app.interactions.test.tsx
@@ -1,9 +1,15 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { MockInstance } from 'vitest'
 import type { FormEvent } from 'react'
 
-import { resetAppSpies } from './utils/renderApp'
+import {
+  fetchCrops,
+  fetchRecommend,
+  fetchRecommendations,
+  renderApp,
+  resetAppSpies,
+} from './utils/renderApp'
 
 type UseRecommendationsModule = typeof import('../src/hooks/useRecommendations')
 
@@ -47,5 +53,70 @@ describe('App interactions', () => {
     fireEvent.change(weekInput, { target: { value: '2024-W31' } })
 
     expect(setQueryWeek).toHaveBeenLastCalledWith('2024-W31')
+  })
+
+  test('フォーム送信・行選択・お気に入り操作が想定通りに動作する', async () => {
+    fetchRecommend.mockRejectedValue(new Error('legacy endpoint disabled'))
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: 'トマト', category: '果菜類' },
+      { id: 2, name: 'レタス', category: '葉菜類' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [
+        {
+          crop: 'トマト',
+          sowing_week: '2024-W28',
+          harvest_week: '2024-W35',
+          source: 'テストデータ',
+          growth_days: 70,
+        },
+        {
+          crop: 'レタス',
+          sowing_week: '2024-W29',
+          harvest_week: '2024-W32',
+          source: 'テストデータ',
+          growth_days: 45,
+        },
+      ],
+    })
+
+    const { user } = await renderApp()
+
+    await screen.findByText('トマト')
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalled()
+    })
+
+    fetchRecommendations.mockClear()
+
+    const weekInput = screen.getByLabelText('週') as HTMLInputElement
+    await user.clear(weekInput)
+    await user.type(weekInput, '2024-W31')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W31')
+    })
+
+    const tomatoCell = screen.getByText('トマト')
+    const tomatoRow = tomatoCell.closest('tr')
+    expect(tomatoRow).not.toBeNull()
+    const selectedRow = tomatoRow as HTMLTableRowElement
+    expect(selectedRow.classList.contains('recommend__row--selected')).toBe(false)
+    await user.click(selectedRow)
+    await waitFor(() => {
+      expect(selectedRow.classList.contains('recommend__row--selected')).toBe(true)
+    })
+
+    const favButton = within(selectedRow).getByRole('button', {
+      name: 'トマトをお気に入りに追加',
+    })
+    expect(favButton.getAttribute('aria-pressed')).toBe('false')
+    await user.click(favButton)
+    await waitFor(() => {
+      expect(favButton.getAttribute('aria-pressed')).toBe('true')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- extend the interaction test to cover form submission, row selection, and favorite toggling
- extract the search controls, recommendations table, and price chart section into dedicated components
- update the app container to orchestrate state while reusing the existing styling

## Testing
- npm run typecheck
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68df105eaf7083218b73db41f1085e13