### PR TITLE
Refactor recommendation fetcher and add normalization tests

### DIFF
--- a/frontend/src/app.behavior.test.tsx
+++ b/frontend/src/app.behavior.test.tsx
@@ -51,6 +51,32 @@ describe('App behavior', () => {
     expect(useRecommendationsSpy).toHaveBeenCalled()
   })
 
+  it('最新API成功時はレガシーAPIを呼び出さない', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+      { id: 2, name: 'にんじん', category: 'root' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    })
+    fetchRecommend.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    })
+
+    await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalledTimes(1)
+      expect(fetchRecommendations).toHaveBeenCalledWith('temperate', '2024-W30')
+    })
+
+    expect(fetchRecommend).not.toHaveBeenCalled()
+  })
+
   it('fetchRecommendations が失敗しても fetchRecommend で初期描画される', async () => {
     fetchCrops.mockResolvedValue([
       { id: 1, name: '春菊', category: 'leaf' },
@@ -108,6 +134,46 @@ describe('App behavior', () => {
     expect(fetchRecommendations).toHaveBeenNthCalledWith(1, 'temperate', '2024-W30')
     expect(fetchRecommend).toHaveBeenCalledWith({ region: 'temperate', week: '2024-W30' })
     expect(screen.getByText('春菊')).toBeInTheDocument()
+  })
+
+  it('週入力は normalizeIsoWeek で揃えてAPIへ送られる', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+      { id: 2, name: 'にんじん', category: 'root' },
+    ])
+    fetchRecommendations.mockImplementation(async (region, week) => {
+      const resolvedWeek = week ?? '2024-W30'
+      return {
+        week: resolvedWeek,
+        region,
+        items: [
+          {
+            crop: '春菊',
+            harvest_week: '2024-W35',
+            sowing_week: '2024-W30',
+            source: 'local-db',
+            growth_days: 42,
+          },
+        ],
+      }
+    })
+
+    const { user } = await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W30')
+    })
+
+    const select = screen.getByLabelText('地域')
+    const weekInput = screen.getByLabelText('週')
+    await user.selectOptions(select, '寒冷地')
+    await user.clear(weekInput)
+    await user.type(weekInput, '2024w33')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('cold', '2024-W33')
+    })
   })
 
   it('地域選択と週入力でAPIが手動フェッチされる', async () => {


### PR DESCRIPTION
## Summary
- add behavior tests to lock the recommendation API usage, fallback handling, and week normalization
- extract recommendation fetching logic into `useRecommendationFetcher` so the loader focuses on state and side effects

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df152418888321b279744e2d8fff84