### PR TITLE
Refine legacy recommendation fallback test setup

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,124 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RecommendResponse } from '../types'
+
+describe('fetchRecommend', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.stubEnv('VITE_API_ENDPOINT', '/api')
+  })
+
+  afterEach(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch
+    } else {
+      Reflect.deleteProperty(globalThis, 'fetch')
+    }
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('sends request through the request helper with query parameters', async () => {
+    const responsePayload: RecommendResponse = {
+      week: '2024-W10',
+      region: 'temperate',
+      items: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => responsePayload,
+    })
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const apiModule = await import('./api')
+    const result = await apiModule.fetchRecommend({ region: 'temperate', week: '2024-W10' })
+
+    expect(result).toEqual(responsePayload)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/recommend?region=temperate&week=2024-W10',
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+
+  it('throws when the request fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal error',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const apiModule = await import('./api')
+
+    await expect(apiModule.fetchRecommend({ region: 'temperate' })).rejects.toThrow('Internal error')
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/recommend?region=temperate',
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+})
+
+describe('useRecommendationLoader fallback', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('uses fetchRecommend when fetchRecommendations fails', async () => {
+    const initialResponse: RecommendResponse = {
+      week: '2024-W05',
+      region: 'temperate',
+      items: [],
+    }
+    const fallbackResponse: RecommendResponse = {
+      week: '2024-W11',
+      region: 'temperate',
+      items: [
+        {
+          crop: 'Carrot',
+          sowing_week: '2024-W10',
+          harvest_week: '2024-W20',
+          source: 'test',
+          growth_days: 70,
+        },
+      ],
+    }
+    const apiModule = await import('./api')
+    const fetchCropsMock = vi.spyOn(apiModule, 'fetchCrops').mockResolvedValue([])
+    const fetchRecommendationsMock = vi
+      .spyOn(apiModule, 'fetchRecommendations')
+      .mockResolvedValueOnce(initialResponse)
+      .mockRejectedValueOnce(new Error('fail'))
+    const fetchRecommendMock = vi
+      .spyOn(apiModule, 'fetchRecommend')
+      .mockResolvedValue(fallbackResponse)
+
+    const { useRecommendationLoader } = await import('../hooks/useRecommendations')
+
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    await waitFor(() => {
+      expect(fetchRecommendationsMock).toHaveBeenCalled()
+    })
+
+    await act(async () => {
+      await result.current.requestRecommendations('2024-W11')
+    })
+
+    await waitFor(() => {
+      expect(fetchRecommendMock).toHaveBeenCalledWith({ region: 'temperate', week: '2024-W11' })
+      expect(result.current.activeWeek).toBe('2024-W11')
+      expect(result.current.items).toEqual(fallbackResponse.items)
+    })
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,17 +39,29 @@ export const fetchCrops = async (): Promise<Crop[]> => {
   return request<Crop[]>(url)
 }
 
-export const fetchRecommendations = async (
-  region: Region,
-  week?: string,
-): Promise<RecommendResponse> => {
+const buildRecommendParams = (region: Region, week?: string): URLSearchParams => {
   const params = new URLSearchParams({ region })
   if (week) {
     params.set('week', week)
   }
-  const url = buildUrl('/recommend', params)
+  return params
+}
+
+export const fetchRecommend = async ({
+  region,
+  week,
+}: {
+  region: Region
+  week?: string
+}): Promise<RecommendResponse> => {
+  const url = buildUrl('/recommend', buildRecommendParams(region, week))
   return request<RecommendResponse>(url)
 }
+
+export const fetchRecommendations = async (
+  region: Region,
+  week?: string,
+): Promise<RecommendResponse> => fetchRecommend({ region, week })
 
 export const postRefresh = async (body?: unknown): Promise<RefreshResponse> => {
   const url = buildUrl('/refresh')


### PR DESCRIPTION
## Summary
- replace the temporary vi.doMock usage with spy-based mocks in the recommendation fallback test
- ensure module cleanup uses restoreAllMocks to avoid syntax issues during type checking
- share the recommend query builder to keep both legacy and new helpers in sync

## Testing
- npm run typecheck
- npm run test -- --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68df105da1288321a0bd2371a5275537