### PR TITLE
Add loading state for price chart fetch

### DIFF
--- a/frontend/src/components/PriceChart.test.tsx
+++ b/frontend/src/components/PriceChart.test.tsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PriceChart } from './PriceChart'
+
+type FetchPrice = typeof import('../lib/api')['fetchPrice']
+type FetchPriceMock = ReturnType<typeof vi.fn<FetchPrice>>
+
+const fetchPrice = vi.hoisted(() => vi.fn<FetchPrice>()) as FetchPriceMock
+
+vi.mock('../lib/api', () => ({
+  fetchPrice,
+}))
+
+describe('PriceChart', () => {
+  beforeEach(() => {
+    fetchPrice.mockReset()
+  })
+
+  it('作物選択直後は価格データ未取得メッセージを表示しない', async () => {
+    fetchPrice.mockReturnValue(new Promise(() => {}) as ReturnType<FetchPrice>)
+
+    render(<PriceChart cropId={1} />)
+
+    await waitFor(() => {
+      expect(fetchPrice).toHaveBeenCalledWith(1, undefined, undefined)
+    })
+
+    expect(screen.queryByText('価格データがありません。')).not.toBeInTheDocument()
+    expect(screen.getByText('価格データを読み込み中です…')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -23,16 +23,22 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
   const [labels, setLabels] = React.useState<string[]>([])
   const [values, setValues] = React.useState<number[]>([])
   const [title, setTitle] = React.useState('')
+  const [isLoading, setIsLoading] = React.useState(false)
 
   React.useEffect(() => {
     if (!cropId) {
       setLabels([])
       setValues([])
       setTitle('')
+      setIsLoading(false)
       return
     }
 
     let active = true
+    setIsLoading(true)
+    setLabels([])
+    setValues([])
+    setTitle('')
     ;(async () => {
       try {
         const res = await fetchPrice(cropId, range?.from, range?.to)
@@ -42,10 +48,15 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
         setLabels(points.map((p) => p.week))
         setValues(points.map((p) => (p.avg_price ?? NaN)))
       } catch {
-        if (!active) return
-        setLabels([])
-        setValues([])
-        setTitle('')
+        if (active) {
+          setLabels([])
+          setValues([])
+          setTitle('')
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false)
+        }
       }
     })()
 
@@ -56,6 +67,10 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
 
   if (!cropId) {
     return <p>作物を選択すると価格推移が表示されます。</p>
+  }
+
+  if (isLoading) {
+    return <p>価格データを読み込み中です…</p>
   }
 
   if (labels.length === 0) {


### PR DESCRIPTION
## Summary
- add an explicit loading state to the price chart so a loading message is shown until price data resolves and "価格データがありません。" only appears for failures or empty results
- add a unit test that keeps fetchPrice pending and asserts the no-data message is hidden immediately after selecting a crop

## Testing
- npm run lint
- npm run typecheck
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68df1a4664908321b9785501286529a4