### PR TITLE
test: verify price fetch on row selection

### DIFF
--- a/frontend/tests/app.interactions.test.tsx
+++ b/frontend/tests/app.interactions.test.tsx
@@ -5,6 +5,7 @@ import type { FormEvent } from 'react'
 
 import {
   fetchCrops,
+  fetchPrice,
   fetchRecommend,
   fetchRecommendations,
   renderApp,
@@ -118,5 +119,47 @@ describe('App interactions', () => {
     await waitFor(() => {
       expect(favButton.getAttribute('aria-pressed')).toBe('true')
     })
+  })
+
+  test('価格チャート用の行選択で fetchPrice が呼び出される', async () => {
+    fetchRecommend.mockRejectedValue(new Error('legacy endpoint disabled'))
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: 'トマト', category: '果菜類' },
+      { id: 2, name: 'レタス', category: '葉菜類' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [
+        {
+          crop: 'トマト',
+          sowing_week: '2024-W28',
+          harvest_week: '2024-W35',
+          source: 'テストデータ',
+          growth_days: 70,
+        },
+      ],
+    })
+    fetchPrice.mockResolvedValue({
+      crop_id: 1,
+      crop: 'トマト',
+      unit: 'kg',
+      source: 'テストデータ',
+      prices: [],
+    })
+
+    const { user } = await renderApp()
+
+    const table = await screen.findByRole('table')
+    const rows = within(table).getAllByRole('row').slice(1)
+    const targetRow = rows.find((row) => within(row).queryByText('トマト'))
+    expect(targetRow).toBeDefined()
+
+    await user.click(targetRow as HTMLTableRowElement)
+
+    await waitFor(() => {
+      expect(fetchPrice).toHaveBeenCalledTimes(1)
+    })
+    expect(fetchPrice).toHaveBeenLastCalledWith(1, undefined, undefined)
   })
 })


### PR DESCRIPTION
## Summary
- add an interaction test that ensures selecting a recommendation row triggers the price fetch

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df1a26aae48321868b76782f8633ea