### PR TITLE
feat: show loading state while fetching price data

### DIFF
--- a/frontend/src/components/PriceChart.test.tsx
+++ b/frontend/src/components/PriceChart.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PriceChart } from './PriceChart'
+import { fetchPrice } from '../lib/api'
+
+vi.mock('../lib/api', () => ({
+  fetchPrice: vi.fn(),
+}))
+
+describe('PriceChart', () => {
+  it('選択直後は未取得メッセージを表示しない', () => {
+    vi.mocked(fetchPrice).mockReturnValue(new Promise(() => {}) as never)
+
+    render(<PriceChart cropId={1} />)
+
+    expect(screen.queryByText('価格データがありません。')).toBeNull()
+  })
+})

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -23,16 +23,22 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
   const [labels, setLabels] = React.useState<string[]>([])
   const [values, setValues] = React.useState<number[]>([])
   const [title, setTitle] = React.useState('')
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [loadedCropId, setLoadedCropId] = React.useState<number | null>(null)
 
   React.useEffect(() => {
     if (!cropId) {
       setLabels([])
       setValues([])
       setTitle('')
+      setIsLoading(false)
+      setLoadedCropId(null)
       return
     }
 
     let active = true
+    setIsLoading(true)
+    setLoadedCropId(null)
     ;(async () => {
       try {
         const res = await fetchPrice(cropId, range?.from, range?.to)
@@ -41,11 +47,15 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
         const points = res.prices ?? []
         setLabels(points.map((p) => p.week))
         setValues(points.map((p) => (p.avg_price ?? NaN)))
+        setLoadedCropId(cropId)
+        setIsLoading(false)
       } catch {
         if (!active) return
         setLabels([])
         setValues([])
         setTitle('')
+        setLoadedCropId(cropId)
+        setIsLoading(false)
       }
     })()
 
@@ -56,6 +66,10 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
 
   if (!cropId) {
     return <p>作物を選択すると価格推移が表示されます。</p>
+  }
+
+  if (isLoading || loadedCropId !== cropId) {
+    return <p>価格データを読み込み中です…</p>
   }
 
   if (labels.length === 0) {


### PR DESCRIPTION
## Summary
- add a loading state to the price chart to display a dedicated message until price data finishes loading
- reset cached crop tracking on new selections so the loading indicator appears for pending fetches and errors
- add a regression test that keeps the "no data" message hidden while price data is still being fetched

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df1a4455c08321b7c5b6dd5b1aeca9