### PR TITLE
docs: update backend testing coverage for price api

### DIFF
--- a/docs/spec/v0.1/TESTING.md
+++ b/docs/spec/v0.1/TESTING.md
@@ -2,7 +2,8 @@
 
 ## 対象範囲
 - **Backend (FastAPI)**
-  - 単体テスト: API レスポンス（/health, /crops, /recommend, /refresh）
+  - 単体テスト: API レスポンス（/api/health, /api/crops, /api/recommend, /api/refresh, /api/refresh/status, /api/price）
+    - 価格 API は不正な週指定時に 400 を返すバリデーションも含めて検証
   - 結合テスト: ETL 実行 → DB 更新 → API 返却の一連動作
   - 静的解析: ruff, black, mypy
 


### PR DESCRIPTION
## Summary
- document backend unit test coverage for the current API endpoints including /api/price
- note the validation scenario for invalid week requests on the price API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1de0624c8321a004360e0313d264