### PR TITLE
fix: stabilize price chart loading state

### DIFF
--- a/frontend/src/components/PriceChart.test.tsx
+++ b/frontend/src/components/PriceChart.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PriceChart } from './PriceChart'
+import { fetchPrice } from '../lib/api'
+
+vi.mock('../lib/api', () => ({
+  fetchPrice: vi.fn(),
+}))
+
+describe('PriceChart', () => {
+  const createDeferred = <T,>() => {
+    let resolve!: (value: T) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+
+  it('選択直後は未取得メッセージを表示しない', async () => {
+    const deferred = createDeferred<Awaited<ReturnType<typeof fetchPrice>>>()
+    vi.mocked(fetchPrice).mockReturnValue(deferred.promise as never)
+
+    render(<PriceChart cropId={1} />)
+
+    expect(screen.queryByText('価格データがありません。')).toBeNull()
+
+    deferred.resolve({ crop_id: 1, crop: 'だみー', unit: 'kg', source: 'test', prices: [] })
+    await screen.findByText('価格データがありません。')
+  })
+})

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -23,16 +23,19 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
   const [labels, setLabels] = React.useState<string[]>([])
   const [values, setValues] = React.useState<number[]>([])
   const [title, setTitle] = React.useState('')
+  const [isLoading, setIsLoading] = React.useState(false)
 
   React.useEffect(() => {
     if (!cropId) {
       setLabels([])
       setValues([])
       setTitle('')
+      setIsLoading(false)
       return
     }
 
     let active = true
+    setIsLoading(true)
     ;(async () => {
       try {
         const res = await fetchPrice(cropId, range?.from, range?.to)
@@ -41,11 +44,13 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
         const points = res.prices ?? []
         setLabels(points.map((p) => p.week))
         setValues(points.map((p) => (p.avg_price ?? NaN)))
+        setIsLoading(false)
       } catch {
         if (!active) return
         setLabels([])
         setValues([])
         setTitle('')
+        setIsLoading(false)
       }
     })()
 
@@ -56,6 +61,10 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
 
   if (!cropId) {
     return <p>作物を選択すると価格推移が表示されます。</p>
+  }
+
+  if (isLoading) {
+    return <p>価格データを読み込み中です…</p>
   }
 
   if (labels.length === 0) {


### PR DESCRIPTION
## Summary
- rely on the existing loading flag in the price chart instead of tracking the loaded crop id
- adjust the loading regression test to use a deferred promise that resolves for cleanup

## Testing
- npm run lint
- npm run typecheck
- npm test -- --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68df1a4455c08321b7c5b6dd5b1aeca9