### PR TITLE
Fix favorites toggle for crop id 0

### DIFF
--- a/frontend/src/components/FavStar.test.tsx
+++ b/frontend/src/components/FavStar.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom/vitest'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useFavorites } from './FavStar'
+
+const loadFavorites = vi.hoisted(() => vi.fn(() => []))
+const saveFavorites = vi.hoisted(() => vi.fn())
+
+vi.mock('../lib/storage', () => ({
+  loadFavorites: loadFavorites as unknown,
+  saveFavorites: saveFavorites as unknown,
+}))
+
+describe('useFavorites', () => {
+  beforeEach(() => {
+    loadFavorites.mockReturnValue([])
+    saveFavorites.mockReset()
+  })
+
+  it('cropId=0 でもお気に入り追加・削除できる', () => {
+    const { result } = renderHook(() => useFavorites())
+
+    expect(result.current.isFavorite(0)).toBe(false)
+
+    act(() => {
+      result.current.toggleFavorite(0)
+    })
+
+    expect(saveFavorites).toHaveBeenCalledWith([0])
+    expect(result.current.isFavorite(0)).toBe(true)
+
+    act(() => {
+      result.current.toggleFavorite(0)
+    })
+
+    expect(saveFavorites).toHaveBeenLastCalledWith([])
+    expect(result.current.isFavorite(0)).toBe(false)
+  })
+})

--- a/frontend/src/components/FavStar.tsx
+++ b/frontend/src/components/FavStar.tsx
@@ -32,7 +32,7 @@ export const useFavorites = () => {
   const [favorites, setFavorites] = useState<number[]>(() => loadFavorites())
 
   const toggleFavorite = useCallback((cropId?: number) => {
-    if (!cropId) {
+    if (cropId === null || cropId === undefined) {
       return
     }
     setFavorites((prev) => {


### PR DESCRIPTION
## Summary
- add a regression test ensuring the favorites hook supports cropId=0
- allow cropId=0 through the favorites toggle guard

## Testing
- npm run test -- --reporter=basic
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68df1f08169c8321a9c8ff3a0547be5f