### PR TITLE
Add app smoke behavior test

### DIFF
--- a/frontend/src/app.behavior.smoke.test.tsx
+++ b/frontend/src/app.behavior.smoke.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  fetchCrops,
+  fetchRecommend,
+  fetchRecommendations,
+  renderApp,
+  resetAppSpies,
+} from '../tests/utils/renderApp'
+
+describe('App smoke behavior', () => {
+  beforeEach(() => {
+    resetAppSpies()
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    })
+    fetchRecommend.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetAppSpies()
+  })
+
+  it('初期描画が成立する', async () => {
+    await renderApp()
+    expect(await screen.findByRole('heading', { name: 'Planting Planner' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add a lightweight smoke test that ensures the app renders with mocked data

## Testing
- npx vitest run src/app.behavior.smoke.test.tsx
- npx vitest run src/app.behavior.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df2383714c8321b9c8c8c0469f93e2