### PR TITLE
Allow crop ID 0 in price chart

### DIFF
--- a/frontend/src/components/PriceChart.test.tsx
+++ b/frontend/src/components/PriceChart.test.tsx
@@ -8,14 +8,27 @@ type FetchPrice = typeof import('../lib/api')['fetchPrice']
 type FetchPriceMock = ReturnType<typeof vi.fn<FetchPrice>>
 
 const fetchPrice = vi.hoisted(() => vi.fn<FetchPrice>()) as FetchPriceMock
+const recordLineProps = vi.hoisted(() =>
+  vi.fn((props: { data: { labels: string[] } }) => {
+    return undefined
+  }),
+)
 
 vi.mock('../lib/api', () => ({
   fetchPrice,
 }))
 
+vi.mock('react-chartjs-2', () => ({
+  Line: (props: { data: { labels: string[] } }) => {
+    recordLineProps(props)
+    return <div data-testid="price-chart" />
+  },
+}))
+
 describe('PriceChart', () => {
   beforeEach(() => {
     fetchPrice.mockReset()
+    recordLineProps.mockReset()
   })
 
   it('作物選択直後は価格データ未取得メッセージを表示しない', async () => {
@@ -29,5 +42,32 @@ describe('PriceChart', () => {
 
     expect(screen.queryByText('価格データがありません。')).not.toBeInTheDocument()
     expect(screen.getByText('価格データを読み込み中です…')).toBeInTheDocument()
+  })
+
+  it('cropId=0 の場合でも価格データを取得しチャート用ラベルを設定する', async () => {
+    fetchPrice.mockResolvedValue({
+      crop_id: 0,
+      crop: 'テスト作物',
+      unit: 'kg',
+      source: 'テスト',
+      prices: [
+        { week: '2024-W01', avg_price: 100 },
+        { week: '2024-W02', avg_price: 200 },
+      ],
+    })
+
+    render(<PriceChart cropId={0} />)
+
+    await waitFor(() => {
+      expect(fetchPrice).toHaveBeenCalledWith(0, undefined, undefined)
+    })
+
+    await waitFor(() => {
+      expect(recordLineProps).toHaveBeenCalled()
+      const calls = recordLineProps.mock.calls
+      expect(calls.length).toBeGreaterThan(0)
+      const [lastCall] = calls[calls.length - 1] as [{ data: { labels: string[] } }]
+      expect(lastCall.data.labels).toEqual(['2024-W01', '2024-W02'])
+    })
   })
 })

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -26,7 +26,7 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
   const [isLoading, setIsLoading] = React.useState(false)
 
   React.useEffect(() => {
-    if (!cropId) {
+    if (cropId == null) {
       setLabels([])
       setValues([])
       setTitle('')
@@ -65,7 +65,7 @@ export const PriceChart: React.FC<PriceChartProps> = ({ cropId, range }) => {
     }
   }, [cropId, range?.from, range?.to])
 
-  if (!cropId) {
+  if (cropId == null) {
     return <p>作物を選択すると価格推移が表示されます。</p>
   }
 


### PR DESCRIPTION
## Summary
- allow the price chart component to treat crop ID 0 as a valid selection by switching to a nullish check
- add a unit test that mocks the chart component to verify cropId=0 triggers fetchPrice and populates labels

## Testing
- npm run test -- --reporter=basic
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df238327308321949ecb1ea4967daf