### PR TITLE
docs: clarify etl status state values

### DIFF
--- a/docs/spec/v0.1/DATA_SCHEMA.md
+++ b/docs/spec/v0.1/DATA_SCHEMA.md
@@ -47,10 +47,10 @@
 |----------------|---------|--------------------------------|
 | id             | INTEGER | 主キー                         |
 | run_at         | TEXT    | 実行時刻（ISO8601文字列）      |
-| status         | TEXT    | 成功/失敗                      |
+| status         | TEXT    | 外部公開ステータス（成功/失敗。実行開始時は `running`） |
 | updated_records| INTEGER | 更新件数                       |
 | error_message  | TEXT    | エラーメッセージ（失敗時）     |
-| state          | TEXT    | ETL ジョブの内部状態（running/success/failure） |
+| state          | TEXT    | ETL ジョブ内部状態（`running`/`success`/`failure`/`stale`） |
 | started_at     | TEXT    | 実行開始時刻（ISO8601文字列）  |
 | finished_at    | TEXT    | 実行終了時刻（ISO8601文字列）  |
 | last_error     | TEXT    | 直近のエラー内容（リトライ用） |


### PR DESCRIPTION
## Summary
- document that etl_runs.status begins as running and enumerates outcomes
- add stale to the list of allowed etl_runs.state values and tidy Japanese phrasing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4a247fe08321803f13aadbebb643