### PR TITLE
Add regression tests and extract recommendation loader logic

### DIFF
--- a/frontend/src/hooks/recommendationLoader.ts
+++ b/frontend/src/hooks/recommendationLoader.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import * as apiModule from '../lib/api'
+import type { RecommendResponse, RecommendationItem, Region } from '../types'
+import {
+  DEFAULT_ACTIVE_WEEK,
+  DEFAULT_WEEK,
+  NormalizeRecommendationResult,
+  normalizeRecommendationResponse,
+} from '../utils/recommendations'
+import { normalizeWeekInput } from '../utils/weekNormalization'
+
+const api = apiModule as typeof import('../lib/api') & {
+  fetchRecommend?: (input: { region: Region; week?: string }) => Promise<RecommendResponse>
+}
+
+export interface RecommendationFetchInput {
+  region: Region
+  week: string
+  preferLegacy?: boolean
+}
+
+export type RecommendationFetcher = (
+  input: RecommendationFetchInput,
+) => Promise<NormalizeRecommendationResult | null>
+
+export const useRecommendationFetcher = (): RecommendationFetcher => {
+  return useCallback<RecommendationFetcher>(
+    async ({ region, week, preferLegacy = false }) => {
+      const callModern = async (): Promise<RecommendResponse | undefined> => {
+        if (typeof api.fetchRecommendations !== 'function') {
+          return undefined
+        }
+        try {
+          return await api.fetchRecommendations(region, week)
+        } catch {
+          return undefined
+        }
+      }
+
+      const callLegacy = async (): Promise<RecommendResponse | undefined> => {
+        if (typeof api.fetchRecommend !== 'function') {
+          return undefined
+        }
+        try {
+          return await api.fetchRecommend({ region, week })
+        } catch {
+          return undefined
+        }
+      }
+
+      const primary = preferLegacy ? callLegacy : callModern
+      const secondary = preferLegacy ? callModern : callLegacy
+
+      const response = (await primary()) ?? (await secondary())
+      if (!response) {
+        return null
+      }
+
+      return normalizeRecommendationResponse(response, week)
+    },
+    [],
+  )
+}
+
+export interface UseRecommendationLoaderResult {
+  queryWeek: string
+  setQueryWeek: (week: string) => void
+  activeWeek: string
+  items: RecommendationItem[]
+  currentWeek: string
+  requestRecommendations: (
+    inputWeek: string,
+    options?: { preferLegacy?: boolean; regionOverride?: Region },
+  ) => Promise<void>
+}
+
+export const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult => {
+  const [queryWeek, setQueryWeek] = useState(DEFAULT_WEEK)
+  const [activeWeek, setActiveWeek] = useState(DEFAULT_ACTIVE_WEEK)
+  const [items, setItems] = useState<RecommendationItem[]>([])
+  const currentWeekRef = useRef<string>(DEFAULT_WEEK)
+  const initialFetchRef = useRef(false)
+  const fetchRecommendationsWithFallback = useRecommendationFetcher()
+
+  const normalizeWeek = useCallback(
+    (value: string) => normalizeWeekInput(value, activeWeek),
+    [activeWeek],
+  )
+
+  const requestRecommendations = useCallback(
+    async (
+      inputWeek: string,
+      options?: { preferLegacy?: boolean; regionOverride?: Region },
+    ) => {
+      const targetRegion = options?.regionOverride ?? region
+      const normalizedWeek = normalizeWeek(inputWeek)
+      setQueryWeek(normalizedWeek)
+      currentWeekRef.current = normalizedWeek
+      try {
+        const result = await fetchRecommendationsWithFallback({
+          region: targetRegion,
+          week: normalizedWeek,
+          preferLegacy: options?.preferLegacy,
+        })
+        if (!result) {
+          setItems([])
+          return
+        }
+        const resolvedWeek = normalizeWeekInput(result.week, activeWeek)
+        setItems(result.items)
+        setActiveWeek(resolvedWeek)
+        currentWeekRef.current = resolvedWeek
+      } catch {
+        setItems([])
+      }
+    },
+    [activeWeek, fetchRecommendationsWithFallback, normalizeWeek, region],
+  )
+
+  useEffect(() => {
+    if (initialFetchRef.current) {
+      return
+    }
+    initialFetchRef.current = true
+    void requestRecommendations(currentWeekRef.current)
+  }, [requestRecommendations])
+
+  return {
+    queryWeek,
+    setQueryWeek,
+    activeWeek,
+    items,
+    currentWeek: currentWeekRef.current,
+    requestRecommendations,
+  }
+}

--- a/frontend/src/hooks/useRecommendations.integration.test.ts
+++ b/frontend/src/hooks/useRecommendations.integration.test.ts
@@ -1,0 +1,127 @@
+import '@testing-library/jest-dom/vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { FormEvent } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useRecommendations } from './useRecommendations'
+
+const fetchCrops = vi.hoisted(() => vi.fn())
+const fetchRecommendations = vi.hoisted(() => vi.fn())
+const fetchRecommend = vi.hoisted(() => vi.fn())
+
+vi.mock('../lib/api', () => ({
+  fetchCrops: fetchCrops as unknown,
+  fetchRecommendations: fetchRecommendations as unknown,
+  fetchRecommend: fetchRecommend as unknown,
+}))
+
+vi.mock('../lib/week', async () => {
+  const actual = await vi.importActual<typeof import('../lib/week')>('../lib/week')
+  return {
+    ...actual,
+    getCurrentIsoWeek: vi.fn(() => '2024-W05'),
+  }
+})
+
+describe('useRecommendations integration', () => {
+  beforeEach(() => {
+    fetchCrops.mockReset()
+    fetchRecommendations.mockReset()
+    fetchRecommend.mockReset()
+
+    fetchCrops.mockResolvedValue([])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W05',
+      items: [],
+    })
+    fetchRecommend.mockResolvedValue({
+      week: '2024-W05',
+      items: [],
+    })
+  })
+
+  it('地域変更時に新しい地域で推奨を再取得する', async () => {
+    const { result } = renderHook(() => useRecommendations({ favorites: [] }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalledWith('temperate', '2024-W05')
+    })
+
+    act(() => {
+      result.current.setRegion('warm')
+    })
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('warm', '2024-W05')
+    })
+  })
+
+  it('週入力を6桁の数値からISO形式に正規化して送信する', async () => {
+    const { result } = renderHook(() => useRecommendations({ favorites: [] }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalledWith('temperate', '2024-W05')
+    })
+
+    const form = document.createElement('form')
+    const weekInput = document.createElement('input')
+    weekInput.name = 'week'
+    weekInput.value = '202413'
+    form.append(weekInput)
+
+    const regionSelect = document.createElement('select')
+    regionSelect.name = 'region'
+    const option = document.createElement('option')
+    option.value = 'temperate'
+    option.selected = true
+    regionSelect.append(option)
+    form.append(regionSelect)
+
+    await act(async () => {
+      result.current.handleSubmit({
+        preventDefault: () => {},
+        currentTarget: form,
+      } as unknown as FormEvent<HTMLFormElement>)
+    })
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W13')
+    })
+  })
+
+  it('モダンAPI失敗時にレガシーAPIへフォールバックし正規化結果を保持する', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: 'Carrot' },
+    ])
+    fetchRecommendations.mockImplementation(async () => {
+      throw new Error('modern failed')
+    })
+    fetchRecommend.mockResolvedValue({
+      week: '202409',
+      items: [
+        {
+          crop: 'Carrot',
+          sowing_week: '2024W01',
+          harvest_week: '2024-W10',
+          score: 10,
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useRecommendations({ favorites: [1] }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalled()
+      expect(fetchRecommend).toHaveBeenCalledWith({ region: 'temperate', week: '2024-W05' })
+      expect(result.current.sortedRows).toHaveLength(1)
+    })
+
+    const [row] = result.current.sortedRows
+    expect(row).toMatchObject({
+      crop: 'Carrot',
+      sowingWeekLabel: '2024-W01',
+      harvestWeekLabel: '2024-W10',
+    })
+    expect(result.current.currentWeek).toBe('2024-W09')
+  })
+})

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -1,26 +1,23 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import * as apiModule from '../lib/api'
-import * as weekModule from '../lib/week'
-import type { Crop, RecommendResponse, RecommendationItem, Region } from '../types'
+import { fetchCrops } from '../lib/api'
+import type { Crop, Region } from '../types'
 import {
-  DEFAULT_ACTIVE_WEEK,
-  DEFAULT_WEEK,
   RecommendationRow,
-  NormalizeRecommendationResult,
   buildRecommendationRows,
   formatWeekLabel,
-  normalizeRecommendationResponse,
 } from '../utils/recommendations'
+import { useRecommendationLoader as useRecommendationLoaderHook } from './recommendationLoader'
 
-const week = weekModule as typeof import('../lib/week')
-
-const api = apiModule as typeof import('../lib/api') & {
-  fetchRecommend?: (input: { region: Region; week?: string }) => Promise<RecommendResponse>
-}
-
-const { normalizeIsoWeek } = week
-const fetchCrops = api.fetchCrops
+export {
+  useRecommendationFetcher,
+  useRecommendationLoader,
+} from './recommendationLoader'
+export type {
+  RecommendationFetchInput,
+  RecommendationFetcher,
+  UseRecommendationLoaderResult,
+} from './recommendationLoader'
 
 export interface UseRecommendationsOptions {
   favorites: readonly number[]
@@ -36,55 +33,6 @@ export interface UseRecommendationsResult {
   displayWeek: string
   sortedRows: RecommendationRow[]
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void
-}
-
-interface RecommendationFetchInput {
-  region: Region
-  week: string
-  preferLegacy?: boolean
-}
-
-export type RecommendationFetcher = (
-  input: RecommendationFetchInput,
-) => Promise<NormalizeRecommendationResult | null>
-
-export const useRecommendationFetcher = (): RecommendationFetcher => {
-  return useCallback<RecommendationFetcher>(
-    async ({ region, week, preferLegacy = false }) => {
-      const callModern = async (): Promise<RecommendResponse | undefined> => {
-        if (typeof api.fetchRecommendations !== 'function') {
-          return undefined
-        }
-        try {
-          return await api.fetchRecommendations(region, week)
-        } catch {
-          return undefined
-        }
-      }
-
-      const callLegacy = async (): Promise<RecommendResponse | undefined> => {
-        if (typeof api.fetchRecommend !== 'function') {
-          return undefined
-        }
-        try {
-          return await api.fetchRecommend({ region, week })
-        } catch {
-          return undefined
-        }
-      }
-
-      const primary = preferLegacy ? callLegacy : callModern
-      const secondary = preferLegacy ? callModern : callLegacy
-
-      const response = (await primary()) ?? (await secondary())
-      if (!response) {
-        return null
-      }
-
-      return normalizeRecommendationResponse(response, week)
-    },
-    [],
-  )
 }
 
 const useCropIndex = (): Map<string, number> => {
@@ -119,98 +67,20 @@ const useCropIndex = (): Map<string, number> => {
   }, [crops])
 }
 
-export interface UseRecommendationLoaderResult {
-  queryWeek: string
-  setQueryWeek: (week: string) => void
-  activeWeek: string
-  items: RecommendationItem[]
-  currentWeek: string
-  requestRecommendations: (
-    inputWeek: string,
-    options?: { preferLegacy?: boolean; regionOverride?: Region },
-  ) => Promise<void>
-}
-
-export const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult => {
-  const [queryWeek, setQueryWeek] = useState(DEFAULT_WEEK)
-  const [activeWeek, setActiveWeek] = useState(DEFAULT_ACTIVE_WEEK)
-  const [items, setItems] = useState<RecommendationItem[]>([])
-  const currentWeekRef = useRef<string>(DEFAULT_WEEK)
-  const initialFetchRef = useRef(false)
-  const fetchRecommendationsWithFallback = useRecommendationFetcher()
-
-  const normalizeWeek = useCallback(
-    (value: string) => {
-      const trimmed = value.trim()
-      if (trimmed) {
-        const digits = trimmed.replace(/[^0-9]/g, '')
-        if (digits.length === 6) {
-          const year = digits.slice(0, 4)
-          const weekPart = digits.slice(4).padStart(2, '0')
-          return `${year}-W${weekPart}`
-        }
-      }
-      return normalizeIsoWeek(value, activeWeek)
-    },
-    [activeWeek],
-  )
-
-  const requestRecommendations = useCallback(
-    async (
-      inputWeek: string,
-      options?: { preferLegacy?: boolean; regionOverride?: Region },
-    ) => {
-      const targetRegion = options?.regionOverride ?? region
-      const normalizedWeek = normalizeWeek(inputWeek)
-      setQueryWeek(normalizedWeek)
-      currentWeekRef.current = normalizedWeek
-      try {
-        const result = await fetchRecommendationsWithFallback({
-          region: targetRegion,
-          week: normalizedWeek,
-          preferLegacy: options?.preferLegacy,
-        })
-        if (!result) {
-          setItems([])
-          return
-        }
-        const resolvedWeek = normalizeWeek(result.week)
-        setItems(result.items)
-        setActiveWeek(resolvedWeek)
-        currentWeekRef.current = resolvedWeek
-      } catch {
-        setItems([])
-      }
-    },
-    [fetchRecommendationsWithFallback, normalizeWeek, region],
-  )
-
-  useEffect(() => {
-    if (initialFetchRef.current) {
-      return
-    }
-    initialFetchRef.current = true
-    void requestRecommendations(currentWeekRef.current)
-  }, [requestRecommendations])
-
-  return {
-    queryWeek,
-    setQueryWeek,
-    activeWeek,
-    items,
-    currentWeek: currentWeekRef.current,
-    requestRecommendations,
-  }
-}
-
 export const useRecommendations = ({ favorites, initialRegion }: UseRecommendationsOptions): UseRecommendationsResult => {
   const initialRegionRef = useRef<Region>(initialRegion ?? 'temperate')
   const [region, setRegion] = useState<Region>(initialRegionRef.current)
   const regionSyncRef = useRef<Region>(initialRegionRef.current)
   const regionFetchSkipRef = useRef<Region | null>(null)
   const cropIndex = useCropIndex()
-  const { queryWeek, setQueryWeek: setRawQueryWeek, activeWeek, items, currentWeek, requestRecommendations } =
-    useRecommendationLoader(region)
+  const {
+    queryWeek,
+    setQueryWeek: setRawQueryWeek,
+    activeWeek,
+    items,
+    currentWeek,
+    requestRecommendations,
+  } = useRecommendationLoaderHook(region)
 
   const setQueryWeek = useCallback(
     (nextWeek: string) => {

--- a/frontend/src/utils/weekNormalization.ts
+++ b/frontend/src/utils/weekNormalization.ts
@@ -1,0 +1,14 @@
+import { normalizeIsoWeek } from '../lib/week'
+
+export const normalizeWeekInput = (value: string, fallbackWeek: string): string => {
+  const trimmed = value.trim()
+  if (trimmed) {
+    const digits = trimmed.replace(/[^0-9]/g, '')
+    if (digits.length === 6) {
+      const year = digits.slice(0, 4)
+      const week = digits.slice(4).padStart(2, '0')
+      return `${year}-W${week}`
+    }
+  }
+  return normalizeIsoWeek(value, fallbackWeek)
+}


### PR DESCRIPTION
## Summary
- add vitest integration coverage for useRecommendations to lock region switching, week normalization, and legacy fallback flows
- extract recommendation fetcher/loader hooks into a dedicated module and reuse a shared week normalization helper
- update useRecommendations to delegate data loading through the new abstractions

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df49fa46f08321adf79d2a62e77670