### PR TITLE
Normalize single-digit ISO weeks in recommendation loader

### DIFF
--- a/frontend/src/hooks/useRecommendations.test.ts
+++ b/frontend/src/hooks/useRecommendations.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+
+import type { Crop, RecommendResponse, Region } from '../types'
+
+const recommendResponse: RecommendResponse = {
+  week: '2024-W06',
+  region: 'temperate',
+  items: [],
+}
+
+type UseRecommendationLoader = typeof import('./useRecommendations')['useRecommendationLoader']
+
+describe('useRecommendationLoader', () => {
+  let useRecommendationLoader: UseRecommendationLoader
+  let fetchRecommendations: MockInstance<
+    (region: Region, week?: string) => Promise<RecommendResponse>
+  >
+  let fetchCrops: MockInstance<() => Promise<Crop[]>>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const api = await import('../lib/api')
+    fetchRecommendations = vi
+      .spyOn(api, 'fetchRecommendations')
+      .mockResolvedValue(recommendResponse)
+    fetchCrops = vi.spyOn(api, 'fetchCrops').mockResolvedValue([])
+    ;({ useRecommendationLoader } = await import('./useRecommendations'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('normalizes numeric 5-digit week inputs before fetching', async () => {
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    fetchRecommendations.mockClear()
+
+    await act(async () => {
+      await result.current.requestRecommendations('2024-W6')
+    })
+
+    expect(fetchRecommendations).toHaveBeenCalledWith('temperate', '2024-W06')
+  })
+})

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -144,7 +144,7 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
       const trimmed = value.trim()
       if (trimmed) {
         const digits = trimmed.replace(/[^0-9]/g, '')
-        if (digits.length === 6) {
+        if (digits.length === 6 || digits.length === 5) {
           const year = digits.slice(0, 4)
           const weekPart = digits.slice(4).padStart(2, '0')
           return `${year}-W${weekPart}`


### PR DESCRIPTION
## Summary
- add a dedicated test for `useRecommendationLoader` to ensure 5-digit week values are normalized before fetching
- update `normalizeWeek` to zero-pad single-digit ISO week numbers when only five digits are present

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df49f9620483219ae8a92bd0b723e7