### PR TITLE
docs: ログ仕様にstale状態を追記

### DIFF
--- a/docs/spec/v0.1/ETL_SPEC.md
+++ b/docs/spec/v0.1/ETL_SPEC.md
@@ -35,7 +35,8 @@ ETL (Extract, Transform, Load) により、公的市場データを週単位に�
 ## ログ
 
 - `etl_runs` テーブルに記録
-  - `state`: ジョブの現在ステータス（`running`/`success`/`failure`）を保持
+  - `state`: ジョブの現在ステータス（`running`/`success`/`failure`/`stale`）を保持し、履歴が存在しない場合は UI からの照会時に `stale` を返す
+  - `status`: 実行開始時に `running` に更新され、UI の進行中表示に利用する
   - `started_at`: ジョブ開始時刻。マイグレーション後は従来の `run_at` と同値で初期化
   - `finished_at`: 正常終了・失敗時の完了時刻。実行中は `NULL`
   - `last_error`: 直近の失敗メッセージ。成功時に `NULL` に戻し、失敗時に更新


### PR DESCRIPTION
## Summary
- ログ節の `state` 説明に `stale` を追加し、履歴なし時のレスポンスを明示
- `status` 列が実行開始時に `running` へ更新される旨を追記

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68df6466a2588321add89310c5077a70