### PR TITLE
Add coverage for single-digit ISO week normalization

### DIFF
--- a/frontend/src/hooks/useRecommendations.test.ts
+++ b/frontend/src/hooks/useRecommendations.test.ts
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RecommendResponse, Region } from '../types'
+
+import { useRecommendationLoader } from './useRecommendations'
+
+type FetchRecommendationsMock = (region: Region, week: string) => Promise<RecommendResponse>
+
+const { fetchCropsMock, fetchRecommendationsMock } = vi.hoisted(() => ({
+  fetchCropsMock: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+  fetchRecommendationsMock: vi.fn<FetchRecommendationsMock>(),
+}))
+
+vi.mock('../lib/api', () => ({
+  fetchCrops: fetchCropsMock,
+  fetchRecommendations: fetchRecommendationsMock,
+}))
+
+describe('useRecommendationLoader', () => {
+  beforeEach(() => {
+    fetchRecommendationsMock.mockReset()
+    fetchRecommendationsMock.mockImplementationOnce(async () => ({
+      week: '2099-W52',
+      region: 'temperate',
+      items: [],
+    }))
+    fetchRecommendationsMock.mockImplementation(async () => ({
+      week: '2024-W06',
+      region: 'temperate',
+      items: [],
+    }))
+    fetchCropsMock.mockClear()
+  })
+
+  it('requestRecommendations は入力週を ISO 形式に正規化して API へ渡す', async () => {
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    fetchRecommendationsMock.mockClear()
+
+    await act(async () => {
+      await result.current.requestRecommendations('2024-W6')
+    })
+
+    expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W06')
+  })
+})

--- a/frontend/src/lib/week.ts
+++ b/frontend/src/lib/week.ts
@@ -74,7 +74,7 @@ export const normalizeIsoWeek = (
   }
 
   const digits = upper.replace(/[^0-9]/g, '')
-  if (digits.length === 6) {
+  if (digits.length === 5 || digits.length === 6) {
     const year = Number(digits.slice(0, 4))
     const week = Number(digits.slice(4))
     if (!Number.isNaN(year) && !Number.isNaN(week)) {


### PR DESCRIPTION
## Summary
- add a hook test to verify requestRecommendations forwards zero-padded ISO week values to the API
- update normalizeIsoWeek to normalize five-digit year-week inputs

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df6455159c8321bebef0c6df31b5ea