### PR TITLE
refactor: extract recommendation fetcher hook

### DIFF
--- a/frontend/src/hooks/recommendationFetcher.ts
+++ b/frontend/src/hooks/recommendationFetcher.ts
@@ -1,0 +1,58 @@
+import { useCallback } from 'react'
+
+import * as apiModule from '../lib/api'
+import type { RecommendResponse, Region } from '../types'
+import { normalizeRecommendationResponse, type NormalizeRecommendationResult } from '../utils/recommendations'
+
+const api = apiModule as typeof import('../lib/api') & {
+  fetchRecommend?: (input: { region: Region; week?: string }) => Promise<RecommendResponse>
+}
+
+interface RecommendationFetchInput {
+  region: Region
+  week: string
+  preferLegacy?: boolean
+}
+
+export type RecommendationFetcher = (
+  input: RecommendationFetchInput,
+) => Promise<NormalizeRecommendationResult | null>
+
+export const useRecommendationFetcher = (): RecommendationFetcher => {
+  return useCallback<RecommendationFetcher>(
+    async ({ region, week, preferLegacy = false }) => {
+      const callModern = async (): Promise<RecommendResponse | undefined> => {
+        if (typeof api.fetchRecommendations !== 'function') {
+          return undefined
+        }
+        try {
+          return await api.fetchRecommendations(region, week)
+        } catch {
+          return undefined
+        }
+      }
+
+      const callLegacy = async (): Promise<RecommendResponse | undefined> => {
+        if (typeof api.fetchRecommend !== 'function') {
+          return undefined
+        }
+        try {
+          return await api.fetchRecommend({ region, week })
+        } catch {
+          return undefined
+        }
+      }
+
+      const primary = preferLegacy ? callLegacy : callModern
+      const secondary = preferLegacy ? callModern : callLegacy
+
+      const response = (await primary()) ?? (await secondary())
+      if (!response) {
+        return null
+      }
+
+      return normalizeRecommendationResponse(response, week)
+    },
+    [],
+  )
+}


### PR DESCRIPTION
## Summary
- extract the recommendation fetching logic into a dedicated hook module
- update the useRecommendations hook to consume the shared fetcher and re-export the fetcher type for compatibility

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68df9055f8288321aa207e3922eff556