### PR TITLE
Ensure recommendation week display stays in sync on failures

### DIFF
--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -184,6 +184,8 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
         }
         if (!result) {
           setItems([])
+          setActiveWeek(normalizedWeek)
+          currentWeekRef.current = normalizedWeek
           return
         }
         const resolvedWeek = normalizeWeek(result.week)
@@ -196,6 +198,8 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
           return
         }
         setItems([])
+        setActiveWeek(normalizedWeek)
+        currentWeekRef.current = normalizedWeek
       }
     },
     [fetchRecommendationsWithFallback, normalizeWeek, region],

--- a/frontend/tests/app.recommendations.test.tsx
+++ b/frontend/tests/app.recommendations.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import {
+  fetchRecommend,
+  fetchRecommendations,
+  fetchCrops,
+  renderApp,
+  resetAppSpies,
+} from './utils/renderApp'
+
+describe('App recommendations', () => {
+  beforeEach(() => {
+    resetAppSpies()
+    fetchCrops.mockResolvedValue([])
+    fetchRecommendations.mockRejectedValue(new Error('modern failed'))
+    fetchRecommend.mockRejectedValue(new Error('legacy failed'))
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetAppSpies()
+  })
+
+  test('両方のAPIが失敗しても基準週が送信週に同期される', async () => {
+    const { user } = await renderApp()
+
+    await screen.findByText('基準週: 2024-W30')
+
+    const weekInput = screen.getByLabelText('週') as HTMLInputElement
+    await user.clear(weekInput)
+    await user.type(weekInput, '2024-W31')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W31')
+    })
+
+    await waitFor(() => {
+      expect(fetchRecommend).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('基準週: 2024-W31')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a regression test covering the week display when both recommendation APIs fail
- update the recommendation loader to keep the active week in sync when requests return null or throw

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df9055ed508321b3851c2a8acc2819