### PR TITLE
Define frontend price series types

### DIFF
--- a/frontend/src/components/PriceChart.test.tsx
+++ b/frontend/src/components/PriceChart.test.tsx
@@ -51,8 +51,8 @@ describe('PriceChart', () => {
       unit: 'kg',
       source: 'テスト',
       prices: [
-        { week: '2024-W01', avg_price: 100 },
-        { week: '2024-W02', avg_price: 200 },
+        { week: '2024-W01', avg_price: 100, stddev: null },
+        { week: '2024-W02', avg_price: 200, stddev: null },
       ],
     })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   Crop,
+  PriceSeries,
   RecommendResponse,
   RefreshResponse,
   RefreshStatusResponse,
@@ -84,16 +85,10 @@ export const fetchPrice = async (
   cropId: number,
   frm?: string,
   to?: string,
-): Promise<{
-  crop_id: number
-  crop: string
-  unit: string
-  source: string
-  prices: { week: string; avg_price: number | null; stddev?: number | null }[]
-}> => {
+): Promise<PriceSeries> => {
   const params = new URLSearchParams({ crop_id: String(cropId) })
   if (frm) params.set('frm', frm)
   if (to) params.set('to', to)
   const url = buildUrl('/price', params)
-  return request(url)
+  return request<PriceSeries>(url)
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,3 +37,17 @@ export interface RegionOption {
   label: string
   value: Region
 }
+
+export interface PricePoint {
+  week: string
+  avg_price: number | null
+  stddev: number | null
+}
+
+export interface PriceSeries {
+  crop_id: number
+  crop: string
+  unit: string
+  source: string
+  prices: PricePoint[]
+}

--- a/frontend/tests/utils/renderApp.tsx
+++ b/frontend/tests/utils/renderApp.tsx
@@ -4,6 +4,7 @@ import { vi } from 'vitest'
 
 import type {
   Crop,
+  PriceSeries,
   RecommendResponse,
   RefreshResponse,
   RefreshStatusResponse,
@@ -58,13 +59,7 @@ export const fetchPrice = vi.fn<
     cropId: number,
     frm?: string,
     to?: string,
-  ) => Promise<{
-    crop_id: number
-    crop: string
-    unit: string
-    source: string
-    prices: { week: string; avg_price: number | null; stddev?: number | null }[]
-  }>
+  ) => Promise<PriceSeries>
 >()
 
 vi.mock('../../src/lib/api', () => ({


### PR DESCRIPTION
## Summary
- add shared PricePoint and PriceSeries interfaces
- update API helpers and mocks to consume the shared types
- adjust price chart test fixtures for the stricter typing

## Testing
- npm run typecheck
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0aa99c77c8321b1fd333f14811578