### PR TITLE
Normalize numeric week inputs via normalizeIsoWeek

### DIFF
--- a/frontend/src/hooks/useRecommendations.test.ts
+++ b/frontend/src/hooks/useRecommendations.test.ts
@@ -48,4 +48,20 @@ describe('useRecommendationLoader', () => {
 
     expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W06')
   })
+
+  it('requestRecommendations は 6 桁の数値入力を最終週へクランプして API へ渡す', async () => {
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    fetchRecommendationsMock.mockClear()
+
+    await act(async () => {
+      await result.current.requestRecommendations('202460')
+    })
+
+    expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W53')
+  })
 })

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -99,10 +99,14 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
       const trimmed = value.trim()
       if (trimmed) {
         const digits = trimmed.replace(/[^0-9]/g, '')
-        if (digits.length === 6) {
+        if (digits.length === 5 || digits.length === 6) {
+          const normalizedDigits = normalizeIsoWeek(digits, activeWeek)
+          if (/^\d{4}-W\d{2}$/.test(normalizedDigits)) {
+            return normalizedDigits
+          }
           const year = digits.slice(0, 4)
-          const weekPart = digits.slice(4).padStart(2, '0')
-          return `${year}-W${weekPart}`
+          const weekPart = digits.slice(4)
+          return normalizeIsoWeek(`${year}-W${weekPart.padStart(2, '0')}`, activeWeek)
         }
       }
       return normalizeIsoWeek(value, activeWeek)


### PR DESCRIPTION
## Summary
- add a regression test ensuring numeric week input is normalized before calling the API
- update the recommendation loader to normalize numeric week strings through normalizeIsoWeek so the value is clamped to 1-53

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0b34f3b1c83219ea72ac6f0fa628f