### PR TITLE
Document stale refresh status response

### DIFF
--- a/docs/spec/v0.1/API_REFERENCE.md
+++ b/docs/spec/v0.1/API_REFERENCE.md
@@ -1,6 +1,7 @@
 # API Reference - planting-planner v0.1
 
 ## 基本情報
+
 - Base URL: `https://<backend-domain>/api`
 - Content-Type: `application/json`
 - 認証: なし（公開利用想定）
@@ -10,8 +11,10 @@
 ## Endpoints
 
 ### `GET /health`
+
 - **概要**: ヘルスチェック
 - **レスポンス例**
+
 ```json
 { "status": "ok" }
 ```
@@ -20,8 +23,8 @@
 
 ### `GET /crops`
 
-* **概要**: 登録済み作物一覧を返す
-* **レスポンス**
+- **概要**: 登録済み作物一覧を返す
+- **レスポンス**
 
 ```json
 [
@@ -38,12 +41,12 @@
 
 ### `GET /recommend`
 
-* **概要**: 「今週植えるべき作物」一覧を返す
-* **クエリパラメータ**
+- **概要**: 「今週植えるべき作物」一覧を返す
+- **クエリパラメータ**
+  - `region` (任意): 推奨ロジックに使用する地域区分（`cold` \| `temperate` \| `warm`、未指定時は `temperate`）
+  - `week` (任意): ISO週番号（未指定の場合は現在週）
 
-  * `region` (任意): 推奨ロジックに使用する地域区分（`cold` \| `temperate` \| `warm`、未指定時は `temperate`）
-  * `week` (任意): ISO週番号（未指定の場合は現在週）
-* **レスポンス**
+- **レスポンス**
 
 ```json
 {
@@ -67,13 +70,13 @@
 
 ### `GET /price`
 
-* **概要**: 指定した作物の週次価格推移を返す
-* **クエリパラメータ**
+- **概要**: 指定した作物の週次価格推移を返す
+- **クエリパラメータ**
+  - `crop_id` (必須): 価格を取得したい作物ID
+  - `frm` (任意): 取得開始週（ISO週形式 `YYYY-Www`）
+  - `to` (任意): 取得終了週（ISO週形式 `YYYY-Www`）
 
-  * `crop_id` (必須): 価格を取得したい作物ID
-  * `frm` (任意): 取得開始週（ISO週形式 `YYYY-Www`）
-  * `to` (任意): 取得終了週（ISO週形式 `YYYY-Www`）
-* **レスポンス (`PriceSeries`)**
+- **レスポンス (`PriceSeries`)**
 
 ```json
 {
@@ -91,7 +94,7 @@
 }
 ```
 
-* **404 レスポンス例**
+- **404 レスポンス例**
 
 ```json
 { "detail": "crop_not_found" }
@@ -101,21 +104,22 @@
 
 ### `POST /refresh`
 
-* **概要**: データ更新を非同期でトリガー
-* **レスポンス**
+- **概要**: データ更新を非同期でトリガー
+- **レスポンス**
 
 ```json
 { "state": "running" }
 ```
 
-  * `state`: 更新ジョブの最新状態（`running`/`success`/`failure`/`stale`）
+- `state`: 更新ジョブの最新状態（`running`/`success`/`failure`/`stale`）
 
 ---
 
 ### `GET /refresh/status`
 
-* **概要**: 最新の更新ジョブの状態を返す
-* **レスポンス**
+- **概要**: 最新の更新ジョブの状態を返す
+- **レスポンス**
+  - 履歴が存在しない場合は `state: "stale"` となり、`started_at`/`finished_at`/`last_error` は `null`、`updated_records` は `0` が返る。
 
 ```json
 {
@@ -127,17 +131,29 @@
 }
 ```
 
+- **履歴なしレスポンス例**
+
+```json
+{
+  "state": "stale",
+  "started_at": null,
+  "finished_at": null,
+  "updated_records": 0,
+  "last_error": null
+}
+```
+
 ---
 
 ## ステータスコード
 
-* `200`: 成功
-* `400`: クエリエラー
-* `500`: サーバ内部エラー
+- `200`: 成功
+- `400`: クエリエラー
+- `500`: サーバ内部エラー
 
 ---
 
 ## 将来拡張
 
-* `/crops/{id}`: 詳細情報取得
-* `/favorites`: ユーザーお気に入り管理（※ v0.1 はフロント側 localStorage 管理）
+- `/crops/{id}`: 詳細情報取得
+- `/favorites`: ユーザーお気に入り管理（※ v0.1 はフロント側 localStorage 管理）


### PR DESCRIPTION
## Summary
- clarify GET /refresh/status behavior when no refresh history exists
- add example response for stale state
- format API reference markdown

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e0ba1a3a6083218a97221d16e576c7