### PR TITLE
Add shared test harness for app utilities

### DIFF
--- a/frontend/tests/utils/interactionsHarness.ts
+++ b/frontend/tests/utils/interactionsHarness.ts
@@ -1,41 +1,32 @@
-import { cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, vi } from 'vitest'
 import type { MockInstance } from 'vitest'
 
-import {
-  fetchCrops,
-  fetchPrice,
-  fetchRecommend,
-  fetchRecommendations,
-  renderApp as baseRenderApp,
-  resetAppSpies,
-} from './renderApp'
+import { createAppTestHarness } from './renderApp'
 
 type UseRecommendationsModule = typeof import('../../src/hooks/useRecommendations')
+type AppHarness = ReturnType<typeof createAppTestHarness>
 
 interface InteractionsHarness {
-  readonly renderApp: typeof baseRenderApp
-  readonly fetchRecommendations: typeof fetchRecommendations
-  readonly fetchRecommend: typeof fetchRecommend
-  readonly fetchCrops: typeof fetchCrops
-  readonly fetchPrice: typeof fetchPrice
+  readonly renderApp: AppHarness['setup']
+  readonly fetchRecommendations: AppHarness['fetchRecommendations']
+  readonly fetchRecommend: AppHarness['fetchRecommend']
+  readonly fetchCrops: AppHarness['fetchCrops']
+  readonly fetchPrice: AppHarness['fetchPrice']
   readonly useRecommendationsSpy: MockInstance
 }
 
 export const createInteractionsHarness = (): InteractionsHarness => {
+  const appHarness = createAppTestHarness()
   let module: UseRecommendationsModule | undefined
   let spy: MockInstance | undefined
 
   beforeEach(async () => {
-    resetAppSpies()
     module = await import('../../src/hooks/useRecommendations')
     spy = vi.spyOn(module, 'useRecommendations')
   })
 
   afterEach(() => {
     spy?.mockRestore()
-    cleanup()
-    resetAppSpies()
   })
 
   const ensureSpy = () => {
@@ -46,11 +37,11 @@ export const createInteractionsHarness = (): InteractionsHarness => {
   }
 
   return {
-    renderApp: baseRenderApp,
-    fetchRecommendations,
-    fetchRecommend,
-    fetchCrops,
-    fetchPrice,
+    renderApp: appHarness.setup,
+    fetchRecommendations: appHarness.fetchRecommendations,
+    fetchRecommend: appHarness.fetchRecommend,
+    fetchCrops: appHarness.fetchCrops,
+    fetchPrice: appHarness.fetchPrice,
     get useRecommendationsSpy() {
       return ensureSpy()
     },

--- a/frontend/tests/utils/renderApp.tsx
+++ b/frontend/tests/utils/renderApp.tsx
@@ -1,6 +1,6 @@
-import { render, waitFor } from '@testing-library/react'
+import { cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
 
 import type {
   Crop,
@@ -96,4 +96,41 @@ export const renderApp = async () => {
     }
   })
   return { user }
+}
+
+interface AppTestHarness {
+  readonly setup: typeof renderApp
+  readonly reset: () => void
+  readonly fetchRecommendations: typeof fetchRecommendations
+  readonly fetchRecommend: typeof fetchRecommend
+  readonly fetchCrops: typeof fetchCrops
+  readonly postRefresh: typeof postRefresh
+  readonly fetchRefreshStatus: typeof fetchRefreshStatus
+  readonly fetchPrice: typeof fetchPrice
+  readonly storage: StorageState
+}
+
+export const createAppTestHarness = (): AppTestHarness => {
+  beforeEach(() => {
+    resetAppSpies()
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetAppSpies()
+  })
+
+  return {
+    setup: renderApp,
+    reset: resetAppSpies,
+    fetchRecommendations,
+    fetchRecommend,
+    fetchCrops,
+    postRefresh,
+    fetchRefreshStatus,
+    fetchPrice,
+    get storage() {
+      return storageState
+    },
+  }
 }


### PR DESCRIPTION
## Summary
- add `createAppTestHarness` to consolidate render/setup logic and shared mocks
- update the interactions harness to consume the shared app harness

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0b9edff648321a7da4e729ea09604