### PR TITLE
Handle week-first inputs for recommendations

### DIFF
--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -98,15 +98,23 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
     (value: string) => {
       const trimmed = value.trim()
       if (trimmed) {
-        const digits = trimmed.replace(/[^0-9]/g, '')
-        if (digits.length === 5 || digits.length === 6) {
-          const normalizedDigits = normalizeIsoWeek(digits, activeWeek)
-          if (/^\d{4}-W\d{2}$/.test(normalizedDigits)) {
-            return normalizedDigits
+        const upper = trimmed.toUpperCase()
+        const weekFirstMatch = upper.match(/^W?(\d{1,2})\D+(\d{4})$/)
+        if (weekFirstMatch) {
+          const weekPart = weekFirstMatch[1]
+          const yearPart = weekFirstMatch[2]
+          if (weekPart && yearPart) {
+            return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
           }
+        }
+
+        const digits = upper.replace(/[^0-9]/g, '')
+        if (digits.length === 5 || digits.length === 6) {
           const year = digits.slice(0, 4)
           const weekPart = digits.slice(4)
-          return normalizeIsoWeek(`${year}-W${weekPart.padStart(2, '0')}`, activeWeek)
+          if (year && weekPart) {
+            return normalizeIsoWeek(`${year}-W${weekPart.padStart(2, '0')}`, activeWeek)
+          }
         }
       }
       return normalizeIsoWeek(value, activeWeek)

--- a/frontend/tests/recommendations/weekNormalization.test.tsx
+++ b/frontend/tests/recommendations/weekNormalization.test.tsx
@@ -1,0 +1,82 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, type MockInstance } from 'vitest'
+
+import {
+  fetchCrops,
+  fetchRecommendations,
+  renderApp,
+} from '../utils/renderApp'
+import {
+  createItem,
+  createRecommendResponse,
+  defaultCrops,
+  setupRecommendationsTest,
+} from '../utils/recommendations'
+
+describe('App recommendations / 週入力正規化', () => {
+  let useRecommendationsSpy: MockInstance
+
+  beforeEach(async () => {
+    ;({ useRecommendationsSpy } = await setupRecommendationsTest())
+  })
+
+  afterEach(() => {
+    useRecommendationsSpy.mockRestore()
+    cleanup()
+  })
+
+  it('週番号が先に来る形式を 2024-W24 に整形して送信する', async () => {
+    fetchCrops.mockResolvedValue(defaultCrops.slice(0, 2))
+    fetchRecommendations.mockImplementation(async (region, week) => {
+      const resolvedWeek = week ?? '2024-W30'
+      return createRecommendResponse({
+        week: resolvedWeek,
+        region,
+        items: [createItem({ crop: '春菊' })],
+      })
+    })
+
+    const { user } = await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W30')
+    })
+
+    const weekInput = screen.getByLabelText('週')
+    await user.clear(weekInput)
+    await user.type(weekInput, 'W24-2024')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W24')
+    })
+  })
+
+  it('週番号が1桁の場合もゼロ埋めして送信する', async () => {
+    fetchCrops.mockResolvedValue(defaultCrops.slice(0, 2))
+    fetchRecommendations.mockImplementation(async (region, week) => {
+      const resolvedWeek = week ?? '2024-W30'
+      return createRecommendResponse({
+        week: resolvedWeek,
+        region,
+        items: [createItem({ crop: '春菊' })],
+      })
+    })
+
+    const { user } = await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W30')
+    })
+
+    const weekInput = screen.getByLabelText('週')
+    await user.clear(weekInput)
+    await user.type(weekInput, 'W6 2024')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W06')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage to ensure week-first week inputs are normalized before fetching recommendations
- update normalizeWeek to rebuild year/week pairs and clamp numeric inputs via normalizeIsoWeek

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0b9ec8cc88321b3fc9e5e3b905fb0