### PR TITLE
Define storage types for frontend tests

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -51,3 +51,13 @@ export interface PriceSeries {
   source: string
   prices: PricePoint[]
 }
+
+/** 地域設定を保存するストレージ構造 */
+export interface RegionStorage {
+  region: Region
+}
+
+/** お気に入り作物IDを保存するストレージ構造 */
+export interface FavoritesStorage {
+  favorites: number[]
+}

--- a/frontend/tests/utils/renderApp.tsx
+++ b/frontend/tests/utils/renderApp.tsx
@@ -4,17 +4,16 @@ import { afterEach, beforeEach, vi } from 'vitest'
 
 import type {
   Crop,
+  FavoritesStorage,
   PriceSeries,
   RecommendResponse,
   RefreshResponse,
   RefreshStatusResponse,
   Region,
+  RegionStorage,
 } from '../../src/types'
 
-interface StorageState {
-  region: Region
-  favorites: number[]
-}
+type StorageState = FavoritesStorage & RegionStorage
 
 export const storageState: StorageState = {
   region: 'temperate',


### PR DESCRIPTION
## Summary
- update test storage state to reuse shared storage types
- add FavoritesStorage and RegionStorage interfaces to the shared types module

## Testing
- `cd frontend && npm run typecheck && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e0d97985588321aacd522a450ee428