### PR TITLE
Refactor ETL runner into modular package

### DIFF
--- a/backend/app/etl_runner.py
+++ b/backend/app/etl_runner.py
@@ -1,246 +1,61 @@
 from __future__ import annotations
 
-import sqlite3
-import time
-from collections.abc import Callable, Iterable
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Final, TypeAlias, cast
+"""Legacy compatibility shim for :mod:`app.etl_runner`."""
 
-from typing_extensions import Protocol
+# TODO [ ] connection.py の直呼びに置き換える
+# TODO [ ] metadata.py の直呼びに置き換える
+# TODO [ ] runner.py の直呼びに置き換える
+# TODO [ ] status.py の直呼びに置き換える
 
-from . import db, schemas
+from importlib import import_module
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-STATE_RUNNING: Final[schemas.RefreshState] = "running"
-STATE_SUCCESS: Final[schemas.RefreshState] = "success"
-STATE_FAILURE: Final[schemas.RefreshState] = "failure"
-STATE_STALE: Final[schemas.RefreshState] = "stale"
+__path__ = [str(Path(__file__).with_name("etl_runner"))]
+_PACKAGE = import_module(f"{__name__}.etl_runner")
+_MODULES = [
+    import_module(f"{__name__}.etl_runner.connection"),
+    import_module(f"{__name__}.etl_runner.metadata"),
+    import_module(f"{__name__}.etl_runner.runner"),
+    import_module(f"{__name__}.etl_runner.status"),
+]
 
-_STATE_LOOKUP: dict[str, schemas.RefreshState] = {
-    STATE_RUNNING: STATE_RUNNING,
-    STATE_SUCCESS: STATE_SUCCESS,
-    STATE_FAILURE: STATE_FAILURE,
-    STATE_STALE: STATE_STALE,
-}
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .etl_runner import *  # noqa: F401,F403
 
-DataLoader: TypeAlias = Callable[[], Iterable[dict[str, Any]]]
+__all__: list[str] = [
+    "STATE_FAILURE",
+    "STATE_RUNNING",
+    "STATE_STALE",
+    "STATE_SUCCESS",
+    "DataLoader",
+    "_RunEtlFactory",
+    "_RunEtlFunc",
+    "_coerce_state",
+    "_ensure_schema",
+    "_insert_run_metadata",
+    "_load_run_etl",
+    "_mark_run_failure",
+    "_mark_run_success",
+    "_open_connection",
+    "_resolve_conn_factory",
+    "_run_etl_with_retries",
+    "_utc_now",
+    "get_last_status",
+    "start_etl_job",
+]
 
-
-class _RunEtlFunc(Protocol):
-    def __call__(
-        self, conn: sqlite3.Connection, *, data_loader: DataLoader | None = None
-    ) -> int: ...
-
-
-_RunEtlFactory: TypeAlias = Callable[[], _RunEtlFunc]
-
-
-def _utc_now() -> str:
-    return datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-if TYPE_CHECKING:
-    from .etl import run_etl as _typed_run_etl
-
-    def _load_run_etl() -> _RunEtlFunc:
-        return _typed_run_etl
-
-else:
-
-    def _load_run_etl() -> _RunEtlFunc:
-        from . import etl as _etl_module
-
-        return cast(_RunEtlFunc, _etl_module.run_etl)
+for _name in __all__:
+    globals()[_name] = getattr(_PACKAGE, _name)
 
 
-def _ensure_schema(conn: sqlite3.Connection) -> None:
-    columns = {row[1] for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()}
-    migrations: dict[str, str] = {
-        "state": "ALTER TABLE etl_runs ADD COLUMN state TEXT",
-        "started_at": "ALTER TABLE etl_runs ADD COLUMN started_at TEXT",
-        "finished_at": "ALTER TABLE etl_runs ADD COLUMN finished_at TEXT",
-        "last_error": "ALTER TABLE etl_runs ADD COLUMN last_error TEXT",
-    }
-    mutated = False
-    for column, ddl in migrations.items():
-        if column not in columns:
-            conn.execute(ddl)
-            mutated = True
-    if mutated:
-        conn.commit()
+def __getattr__(name: str) -> Any:
+    return getattr(_PACKAGE, name)
 
 
-def _coerce_state(value: Any) -> schemas.RefreshState:
-    if isinstance(value, str):
-        normalized = value.lower()
-        state = _STATE_LOOKUP.get(normalized)
-        if state is not None:
-            return state
-    return STATE_STALE
-
-
-def _resolve_conn_factory(
-    conn_factory: Callable[[], sqlite3.Connection] | None,
-) -> Callable[[], sqlite3.Connection]:
-    if conn_factory is not None:
-        return conn_factory
-    return lambda: db.get_conn()
-
-
-def _open_connection(factory: Callable[[], sqlite3.Connection]) -> sqlite3.Connection:
-    return factory()
-
-
-def _insert_run_metadata(conn: sqlite3.Connection, started_at: str) -> int:
-    cursor = conn.execute(
-        """
-        INSERT INTO etl_runs (
-            run_at,
-            status,
-            updated_records,
-            error_message,
-            state,
-            started_at,
-            finished_at,
-            last_error
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (started_at, STATE_RUNNING, 0, None, STATE_RUNNING, started_at, None, None),
-    )
-    run_id_raw = cursor.lastrowid
-    if run_id_raw is None:  # pragma: no cover - SQLite guarantees an id for AUTOINCREMENT
-        raise RuntimeError("Failed to persist ETL run metadata")
-    conn.commit()
-    return int(run_id_raw)
-
-
-def _mark_run_failure(
-    conn: sqlite3.Connection, run_id: int, *, finished_at: str, error_message: str
-) -> None:
-    conn.execute(
-        """
-        UPDATE etl_runs
-        SET status = ?,
-            state = ?,
-            finished_at = ?,
-            last_error = ?,
-            error_message = ?
-        WHERE id = ?
-        """,
-        (STATE_FAILURE, STATE_FAILURE, finished_at, error_message, error_message, run_id),
-    )
-    conn.commit()
-
-
-def _mark_run_success(
-    conn: sqlite3.Connection, run_id: int, *, finished_at: str, updated_records: int
-) -> None:
-    conn.execute(
-        """
-        UPDATE etl_runs
-        SET status = ?,
-            state = ?,
-            finished_at = ?,
-            updated_records = ?,
-            last_error = NULL,
-            error_message = NULL
-        WHERE id = ?
-        """,
-        (STATE_SUCCESS, STATE_SUCCESS, finished_at, updated_records, run_id),
-    )
-    conn.commit()
-
-
-def _run_etl_with_retries(
-    *,
-    load_run_etl: _RunEtlFactory,
-    conn: sqlite3.Connection,
-    data_loader: DataLoader | None,
-    max_retries: int,
-    retry_delay: float,
-) -> int:
-    attempt = 0
-    while True:
-        try:
-            run_etl = load_run_etl()
-            return run_etl(conn, data_loader=data_loader)
-        except sqlite3.DatabaseError:
-            attempt += 1
-            if attempt >= max_retries:
-                raise
-            if retry_delay:
-                time.sleep(retry_delay)
-
-
-def start_etl_job(
-    *,
-    data_loader: DataLoader | None = None,
-    conn_factory: Callable[[], sqlite3.Connection] | None = None,
-    max_retries: int = 3,
-    retry_delay: float = 0.1,
-) -> None:
-    factory = _resolve_conn_factory(conn_factory)
-    conn = _open_connection(factory)
-    try:
-        _ensure_schema(conn)
-        started_at = _utc_now()
-        run_id = _insert_run_metadata(conn, started_at)
-        try:
-            updated_records = _run_etl_with_retries(
-                load_run_etl=_load_run_etl,
-                conn=conn,
-                data_loader=data_loader,
-                max_retries=max_retries,
-                retry_delay=retry_delay,
-            )
-        except Exception as exc:  # pragma: no cover - defensive path
-            finished_at = _utc_now()
-            _mark_run_failure(conn, run_id, finished_at=finished_at, error_message=str(exc))
-            raise
-        else:
-            finished_at = _utc_now()
-            _mark_run_success(
-                conn,
-                run_id,
-                finished_at=finished_at,
-                updated_records=updated_records,
-            )
-    finally:
-        conn.close()
-
-
-def get_last_status(conn: sqlite3.Connection) -> schemas.RefreshStatus:
-    _ensure_schema(conn)
-    row = conn.execute(
-        """
-        SELECT
-            COALESCE(state, status) AS state,
-            COALESCE(started_at, run_at) AS started_at,
-            finished_at,
-            updated_records,
-            COALESCE(last_error, error_message) AS last_error,
-            run_at
-        FROM etl_runs
-        ORDER BY COALESCE(started_at, run_at) DESC
-        LIMIT 1
-        """,
-    ).fetchone()
-    if row is None:
-        return schemas.RefreshStatus(
-            state="stale",
-            started_at=None,
-            finished_at=None,
-            updated_records=0,
-            last_error=None,
-        )
-
-    state = _coerce_state(row["state"])
-    finished_at = cast(str | None, row["finished_at"])
-    raw_updated_records = cast(int | None, row["updated_records"])
-    updated_records = 0 if raw_updated_records is None else int(raw_updated_records)
-    return schemas.RefreshStatus(
-        state=state,
-        started_at=row["started_at"],
-        finished_at=finished_at,
-        updated_records=updated_records,
-        last_error=cast(str | None, row["last_error"]),
-    )
+def __setattr__(name: str, value: Any) -> None:
+    setattr(_PACKAGE, name, value)
+    for module in _MODULES:
+        if hasattr(module, name):
+            setattr(module, name, value)
+    globals()[name] = value

--- a/backend/app/etl_runner/__init__.py
+++ b/backend/app/etl_runner/__init__.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from .connection import _open_connection, _resolve_conn_factory
+from .metadata import (
+    STATE_FAILURE,
+    STATE_RUNNING,
+    STATE_STALE,
+    STATE_SUCCESS,
+    _ensure_schema,
+    _insert_run_metadata,
+    _mark_run_failure,
+    _mark_run_success,
+)
+from .runner import (
+    DataLoader,
+    _RunEtlFactory,
+    _RunEtlFunc,
+    _load_run_etl,
+    _run_etl_with_retries,
+    _utc_now,
+    start_etl_job,
+)
+from .status import _coerce_state, get_last_status
+
+__all__ = [
+    "STATE_FAILURE",
+    "STATE_RUNNING",
+    "STATE_STALE",
+    "STATE_SUCCESS",
+    "DataLoader",
+    "_RunEtlFactory",
+    "_RunEtlFunc",
+    "_coerce_state",
+    "_ensure_schema",
+    "_insert_run_metadata",
+    "_load_run_etl",
+    "_mark_run_failure",
+    "_mark_run_success",
+    "_open_connection",
+    "_resolve_conn_factory",
+    "_run_etl_with_retries",
+    "_utc_now",
+    "get_last_status",
+    "start_etl_job",
+]

--- a/backend/app/etl_runner/connection.py
+++ b/backend/app/etl_runner/connection.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+
+from .. import db
+
+
+def _resolve_conn_factory(
+    conn_factory: Callable[[], sqlite3.Connection] | None,
+) -> Callable[[], sqlite3.Connection]:
+    if conn_factory is not None:
+        return conn_factory
+    return lambda: db.get_conn()
+
+
+def _open_connection(factory: Callable[[], sqlite3.Connection]) -> sqlite3.Connection:
+    return factory()

--- a/backend/app/etl_runner/metadata.py
+++ b/backend/app/etl_runner/metadata.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Final
+
+from .. import schemas
+
+STATE_RUNNING: Final[schemas.RefreshState] = "running"
+STATE_SUCCESS: Final[schemas.RefreshState] = "success"
+STATE_FAILURE: Final[schemas.RefreshState] = "failure"
+STATE_STALE: Final[schemas.RefreshState] = "stale"
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    columns = {row[1] for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()}
+    migrations: dict[str, str] = {
+        "state": "ALTER TABLE etl_runs ADD COLUMN state TEXT",
+        "started_at": "ALTER TABLE etl_runs ADD COLUMN started_at TEXT",
+        "finished_at": "ALTER TABLE etl_runs ADD COLUMN finished_at TEXT",
+        "last_error": "ALTER TABLE etl_runs ADD COLUMN last_error TEXT",
+    }
+    mutated = False
+    for column, ddl in migrations.items():
+        if column not in columns:
+            conn.execute(ddl)
+            mutated = True
+    if mutated:
+        conn.commit()
+
+
+def _insert_run_metadata(conn: sqlite3.Connection, started_at: str) -> int:
+    cursor = conn.execute(
+        """
+        INSERT INTO etl_runs (
+            run_at,
+            status,
+            updated_records,
+            error_message,
+            state,
+            started_at,
+            finished_at,
+            last_error
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (started_at, STATE_RUNNING, 0, None, STATE_RUNNING, started_at, None, None),
+    )
+    run_id_raw = cursor.lastrowid
+    if run_id_raw is None:  # pragma: no cover - SQLite guarantees an id for AUTOINCREMENT
+        raise RuntimeError("Failed to persist ETL run metadata")
+    conn.commit()
+    return int(run_id_raw)
+
+
+def _mark_run_failure(
+    conn: sqlite3.Connection, run_id: int, *, finished_at: str, error_message: str
+) -> None:
+    conn.execute(
+        """
+        UPDATE etl_runs
+        SET status = ?,
+            state = ?,
+            finished_at = ?,
+            last_error = ?,
+            error_message = ?
+        WHERE id = ?
+        """,
+        (STATE_FAILURE, STATE_FAILURE, finished_at, error_message, error_message, run_id),
+    )
+    conn.commit()
+
+
+def _mark_run_success(
+    conn: sqlite3.Connection, run_id: int, *, finished_at: str, updated_records: int
+) -> None:
+    conn.execute(
+        """
+        UPDATE etl_runs
+        SET status = ?,
+            state = ?,
+            finished_at = ?,
+            updated_records = ?,
+            last_error = NULL,
+            error_message = NULL
+        WHERE id = ?
+        """,
+        (STATE_SUCCESS, STATE_SUCCESS, finished_at, updated_records, run_id),
+    )
+    conn.commit()

--- a/backend/app/etl_runner/runner.py
+++ b/backend/app/etl_runner/runner.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
+
+from typing_extensions import Protocol
+
+from . import connection, metadata
+
+DataLoader: TypeAlias = Callable[[], Iterable[dict[str, Any]]]
+
+
+class _RunEtlFunc(Protocol):
+    def __call__(
+        self, conn: sqlite3.Connection, *, data_loader: DataLoader | None = None
+    ) -> int: ...
+
+
+_RunEtlFactory: TypeAlias = Callable[[], _RunEtlFunc]
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+if TYPE_CHECKING:
+    from ..etl import run_etl as _typed_run_etl
+
+    def _load_run_etl() -> _RunEtlFunc:
+        return _typed_run_etl
+
+else:
+
+    def _load_run_etl() -> _RunEtlFunc:
+        from .. import etl as _etl_module  # Local import to avoid circular dependency
+
+        return cast(_RunEtlFunc, _etl_module.run_etl)
+
+
+def _resolve_run_etl_factory() -> _RunEtlFactory:
+    from .. import etl_runner as shim
+
+    factory = getattr(shim, "_load_run_etl")
+    return cast(_RunEtlFactory, factory)
+
+
+def _run_etl_with_retries(
+    *,
+    load_run_etl: _RunEtlFactory,
+    conn: sqlite3.Connection,
+    data_loader: DataLoader | None,
+    max_retries: int,
+    retry_delay: float,
+) -> int:
+    attempt = 0
+    while True:
+        try:
+            run_etl = load_run_etl()
+            return run_etl(conn, data_loader=data_loader)
+        except sqlite3.DatabaseError:
+            attempt += 1
+            if attempt >= max_retries:
+                raise
+            if retry_delay:
+                time.sleep(retry_delay)
+
+
+def start_etl_job(
+    *,
+    data_loader: DataLoader | None = None,
+    conn_factory: Callable[[], sqlite3.Connection] | None = None,
+    max_retries: int = 3,
+    retry_delay: float = 0.1,
+) -> None:
+    factory = connection._resolve_conn_factory(conn_factory)
+    conn = connection._open_connection(factory)
+    try:
+        metadata._ensure_schema(conn)
+        started_at = _utc_now()
+        run_id = metadata._insert_run_metadata(conn, started_at)
+        try:
+            load_run_etl = _resolve_run_etl_factory()
+            updated_records = _run_etl_with_retries(
+                load_run_etl=load_run_etl,
+                conn=conn,
+                data_loader=data_loader,
+                max_retries=max_retries,
+                retry_delay=retry_delay,
+            )
+        except Exception as exc:  # pragma: no cover - defensive path
+            finished_at = _utc_now()
+            metadata._mark_run_failure(
+                conn, run_id, finished_at=finished_at, error_message=str(exc)
+            )
+            raise
+        else:
+            finished_at = _utc_now()
+            metadata._mark_run_success(
+                conn, run_id, finished_at=finished_at, updated_records=updated_records
+            )
+    finally:
+        conn.close()

--- a/backend/app/etl_runner/status.py
+++ b/backend/app/etl_runner/status.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, cast
+
+from .. import schemas
+from . import metadata
+
+_STATE_LOOKUP: dict[str, schemas.RefreshState] = {
+    metadata.STATE_RUNNING: metadata.STATE_RUNNING,
+    metadata.STATE_SUCCESS: metadata.STATE_SUCCESS,
+    metadata.STATE_FAILURE: metadata.STATE_FAILURE,
+    metadata.STATE_STALE: metadata.STATE_STALE,
+}
+
+
+def _coerce_state(value: Any) -> schemas.RefreshState:
+    if isinstance(value, str):
+        normalized = value.lower()
+        state = _STATE_LOOKUP.get(normalized)
+        if state is not None:
+            return state
+    return metadata.STATE_STALE
+
+
+def get_last_status(conn: sqlite3.Connection) -> schemas.RefreshStatus:
+    metadata._ensure_schema(conn)
+    row = conn.execute(
+        """
+        SELECT
+            COALESCE(state, status) AS state,
+            COALESCE(started_at, run_at) AS started_at,
+            finished_at,
+            updated_records,
+            COALESCE(last_error, error_message) AS last_error,
+            run_at
+        FROM etl_runs
+        ORDER BY COALESCE(started_at, run_at) DESC
+        LIMIT 1
+        """,
+    ).fetchone()
+    if row is None:
+        return schemas.RefreshStatus(
+            state="stale",
+            started_at=None,
+            finished_at=None,
+            updated_records=0,
+            last_error=None,
+        )
+
+    state = _coerce_state(row["state"])
+    finished_at = cast(str | None, row["finished_at"])
+    raw_updated_records = cast(int | None, row["updated_records"])
+    updated_records = 0 if raw_updated_records is None else int(raw_updated_records)
+    return schemas.RefreshStatus(
+        state=state,
+        started_at=row["started_at"],
+        finished_at=finished_at,
+        updated_records=updated_records,
+        last_error=cast(str | None, row["last_error"]),
+    )

--- a/backend/tests/test_etl.py
+++ b/backend/tests/test_etl.py
@@ -25,6 +25,72 @@ def _prepare_crops(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def test_resolve_conn_factory_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"count": 0}
+
+    def fake_get_conn() -> sqlite3.Connection:
+        calls["count"] += 1
+        return _make_conn()
+
+    monkeypatch.setattr(db, "get_conn", fake_get_conn)
+
+    factory = etl_runner._resolve_conn_factory(None)
+    with factory() as conn:  # type: ignore[call-arg]
+        assert isinstance(conn, sqlite3.Connection)
+
+    assert calls["count"] == 1
+
+
+def test_ensure_schema_backfills_missing_columns(tmp_path: Path) -> None:
+    conn = _make_conn(tmp_path / "legacy.db")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE etl_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_at TEXT NOT NULL,
+                status TEXT NOT NULL,
+                updated_records INTEGER NOT NULL,
+                error_message TEXT
+            )
+            """
+        )
+        conn.commit()
+
+        etl_runner._ensure_schema(conn)
+
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()
+        }
+        assert {"state", "started_at", "finished_at", "last_error"}.issubset(columns)
+    finally:
+        conn.close()
+
+
+def test_insert_run_metadata_persists_defaults() -> None:
+    conn = _make_conn()
+    try:
+        db.init_db(conn)
+        started_at = "2024-05-01T00:00:00Z"
+
+        run_id = etl_runner._insert_run_metadata(conn, started_at)
+
+        row = conn.execute(
+            "SELECT status, state, updated_records, last_error, error_message"
+            " FROM etl_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["status"] == "running"
+        assert row["state"] == "running"
+        assert row["updated_records"] == 0
+        assert row["last_error"] is None
+        assert row["error_message"] is None
+    finally:
+        conn.close()
+
+
 def test_run_etl_transforms_and_upserts_weekly_prices() -> None:
     conn = _make_conn()
     try:


### PR DESCRIPTION
## Summary
- add regression tests to pin connection resolution, schema migrations, and metadata defaults for ETL runner
- split the ETL runner into a dedicated package with connection, metadata, runner, and status modules and expose them through a legacy shim

## Testing
- pytest -q
- mypy app/etl_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d9560a8083218ed705cd1f2d1b89