### PR TITLE
Support date inputs when requesting recommendations

### DIFF
--- a/frontend/src/hooks/useRecommendations.test.ts
+++ b/frontend/src/hooks/useRecommendations.test.ts
@@ -59,6 +59,38 @@ describe('useRecommendationLoader', () => {
     expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W06')
   })
 
+  it('requestRecommendations は日付形式 (YYYY-MM-DD) を ISO 週へ変換して API へ渡す', async () => {
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    fetchRecommendationsMock.mockClear()
+
+    await act(async () => {
+      await result.current.requestRecommendations('2024-07-01')
+    })
+
+    expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W27')
+  })
+
+  it('requestRecommendations は日付形式 (YYYY/MM/DD) を ISO 週へ変換して API へ渡す', async () => {
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    fetchRecommendationsMock.mockClear()
+
+    await act(async () => {
+      await result.current.requestRecommendations('2024/07/01')
+    })
+
+    expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W27')
+  })
+
   it('requestRecommendations は 6 桁の数値入力を最終週へクランプして API へ渡す', async () => {
     const { result } = renderHook(() => useRecommendationLoader('temperate'))
 


### PR DESCRIPTION
## Summary
- add coverage for date-formatted week inputs in useRecommendationLoader tests
- normalize date strings into ISO week values when requesting recommendations

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0d955118883219b9f7bf5b6158c06