### PR TITLE
Add API response type definitions and tests

### DIFF
--- a/frontend/src/types.test.ts
+++ b/frontend/src/types.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expectTypeOf } from 'vitest'
+
+import type { CropsResponse, GrowthDays, HealthResponse } from './types'
+
+describe('Type definitions', () => {
+  it('defines HealthResponse structure', () => {
+    expectTypeOf<HealthResponse>().toEqualTypeOf<{ status: string }>()
+  })
+
+  it('defines CropsResponse as an array of Crop', () => {
+    expectTypeOf<CropsResponse>().toEqualTypeOf<import('./types').Crop[]>()
+  })
+
+  it('defines GrowthDays mapping', () => {
+    expectTypeOf<GrowthDays>().toEqualTypeOf<{
+      crop_id: number
+      region: import('./types').Region
+      days: number
+    }>()
+  })
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,21 @@ export interface Crop {
   category: string
 }
 
+/** 作物の生育期間メタデータ */
+export interface GrowthDays {
+  crop_id: number
+  region: Region
+  days: number
+}
+
+/** 作物一覧 API レスポンス */
+export type CropsResponse = Crop[]
+
+/** ヘルスチェック API レスポンス */
+export interface HealthResponse {
+  status: string
+}
+
 export interface RecommendationItem {
   crop: string
   sowing_week: string


### PR DESCRIPTION
## Summary
- add vitest type assertions for HealthResponse, CropsResponse, and GrowthDays
- define the missing API-related types in the shared frontend type module

## Testing
- `cd frontend && npm run typecheck`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e0ddb369948321a775bdbcd93a9e5d