### PR TITLE
Refactor seed logic into dedicated package

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,124 +1,33 @@
+"""Legacy compatibility shim for seed routines.
+
+This module remains to avoid breaking imports while the seeding
+implementation lives in :mod:`backend.app.seed`. When editing, confirm:
+- New entry points stay re-exported here.
+- Default behaviour matches :mod:`backend.app.seed`.
+"""
+
 from __future__ import annotations
 
-import json
-import sqlite3
-from pathlib import Path
-from typing import Any
+from .seed import (  # noqa: F401
+    DEFAULT_DATA_DIR,
+    SeedPayload,
+    load_seed_payload,
+    seed,
+    seed_from_default_db,
+    write_crops,
+    write_growth_days,
+    write_price_samples,
+    write_seed_payload,
+)
 
-from . import db, utils_week
-
-DATA_DIR = Path(__file__).resolve().parents[2] / "data"
-_NUMERIC_TYPES = (int, float, str)
-
-
-def _optional_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, _NUMERIC_TYPES):
-        return float(value)
-    raise TypeError(f"Unsupported numeric value: {value!r}")
-
-
-def _load_json(path: Path) -> list[dict[str, Any]]:
-    with path.open("r", encoding="utf-8") as fh:
-        payload = json.load(fh)
-    if not isinstance(payload, list):
-        raise ValueError(f"Expected list in {path}")
-    return [dict(item) for item in payload]
-
-
-def seed(conn: sqlite3.Connection | None = None) -> None:
-    close_conn = False
-    if conn is None:
-        conn = db.get_conn()
-        close_conn = True
-
-    db.init_db(conn)
-
-    crops_path = DATA_DIR / "crops.json"
-    growth_days_path = DATA_DIR / "growth_days.json"
-
-    crops_data = _load_json(crops_path)
-    growth_days_data = _load_json(growth_days_path)
-    price_sample_path = DATA_DIR / "price_weekly.sample.json"
-    price_sample_data: list[dict[str, Any]] = []
-    if price_sample_path.exists():
-        price_sample_data = _load_json(price_sample_path)
-
-    for crop in crops_data:
-        crop_id = int(crop["id"])
-        name = crop["name"]
-        category = crop["category"]
-        conn.execute(
-            "INSERT OR IGNORE INTO crops (id, name, category) VALUES (?, ?, ?)",
-            (crop_id, name, category),
-        )
-        conn.execute(
-            "UPDATE crops SET name = ?, category = ? WHERE id = ?",
-            (name, category, crop_id),
-        )
-
-        for price in crop.get("price_weekly", []):
-            week_value = price["week"]
-            if isinstance(week_value, int):
-                week_iso = utils_week.iso_week_from_int(int(week_value))
-            else:
-                week_iso = str(week_value)
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO price_weekly (
-                    crop_id, week, avg_price, stddev, unit, source
-                ) VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    crop_id,
-                    week_iso,
-                    _optional_float(price.get("price")),
-                    _optional_float(price.get("stddev")),
-                    price.get("unit", "円/kg"),
-                    price.get("source", "seed"),
-                ),
-            )
-
-    for row in price_sample_data:
-        week_iso = str(row["week"])
-        conn.execute(
-            """
-            INSERT OR IGNORE INTO price_weekly (
-                crop_id, week, avg_price, stddev, unit, source
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                int(row["crop_id"]),
-                week_iso,
-                _optional_float(row.get("avg_price")),
-                _optional_float(row.get("stddev")),
-                row.get("unit", "円/kg"),
-                row.get("source", "seed"),
-            ),
-        )
-
-    for entry in growth_days_data:
-        crop_id = int(entry["crop_id"])
-        conn.execute(
-            "INSERT OR IGNORE INTO growth_days (crop_id, region, days) VALUES (?, ?, ?)",
-            (crop_id, entry["region"], int(entry["days"])),
-        )
-        conn.execute(
-            "UPDATE growth_days SET days = ? WHERE crop_id = ? AND region = ?",
-            (int(entry["days"]), crop_id, entry["region"]),
-        )
-
-    conn.commit()
-
-    if close_conn:
-        conn.close()
-
-
-def seed_from_default_db() -> None:
-    conn = db.get_conn()
-    try:
-        db.init_db(conn)
-        seed(conn)
-    finally:
-        conn.close()
+__all__ = [
+    "DEFAULT_DATA_DIR",
+    "SeedPayload",
+    "load_seed_payload",
+    "seed",
+    "seed_from_default_db",
+    "write_crops",
+    "write_growth_days",
+    "write_price_samples",
+    "write_seed_payload",
+]

--- a/backend/app/seed/__init__.py
+++ b/backend/app/seed/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from .. import db
+from .data_loader import DEFAULT_DATA_DIR, SeedPayload, load_seed_payload
+from .writers import write_crops, write_growth_days, write_price_samples, write_seed_payload
+
+__all__ = [
+    "DEFAULT_DATA_DIR",
+    "SeedPayload",
+    "load_seed_payload",
+    "seed",
+    "seed_from_default_db",
+    "write_crops",
+    "write_growth_days",
+    "write_price_samples",
+    "write_seed_payload",
+]
+
+
+def seed(conn: sqlite3.Connection | None = None, data_dir: Path | None = None) -> None:
+    close_conn = False
+    if conn is None:
+        conn = db.get_conn()
+        close_conn = True
+
+    db.init_db(conn)
+    payload = load_seed_payload(data_dir=data_dir)
+    write_seed_payload(
+        conn,
+        crops=payload.crops,
+        price_samples=payload.price_samples,
+        growth_days=payload.growth_days,
+    )
+    conn.commit()
+
+    if close_conn:
+        conn.close()
+
+
+def seed_from_default_db() -> None:
+    conn = db.get_conn()
+    try:
+        db.init_db(conn)
+        seed(conn)
+    finally:
+        conn.close()

--- a/backend/app/seed/data_loader.py
+++ b/backend/app/seed/data_loader.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATA_DIR = Path(__file__).resolve().parents[3] / "data"
+
+
+@dataclass(frozen=True)
+class SeedPayload:
+    crops: list[dict[str, Any]]
+    price_samples: list[dict[str, Any]]
+    growth_days: list[dict[str, Any]]
+
+
+def _ensure_list(payload: Any, *, source: Path) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise ValueError(f"Expected list in {source}")
+    return [dict(item) for item in payload]
+
+
+def _load_json(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fh:
+        return _ensure_list(json.load(fh), source=path)
+
+
+def load_seed_payload(data_dir: Path | None = None) -> SeedPayload:
+    base_dir = data_dir or DEFAULT_DATA_DIR
+    crops_data = _load_json(base_dir / "crops.json")
+    growth_days_data = _load_json(base_dir / "growth_days.json")
+
+    price_sample_path = base_dir / "price_weekly.sample.json"
+    price_sample_data: list[dict[str, Any]] = []
+    if price_sample_path.exists():
+        price_sample_data = _load_json(price_sample_path)
+
+    return SeedPayload(
+        crops=crops_data,
+        price_samples=price_sample_data,
+        growth_days=growth_days_data,
+    )
+
+
+__all__ = [
+    "DEFAULT_DATA_DIR",
+    "SeedPayload",
+    "load_seed_payload",
+]

--- a/backend/app/seed/writers.py
+++ b/backend/app/seed/writers.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Iterable, Mapping
+
+from .. import utils_week
+
+_NUMERIC_TYPES = (int, float, str)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, _NUMERIC_TYPES):
+        return float(value)
+    raise TypeError(f"Unsupported numeric value: {value!r}")
+
+
+def _iter_price_records(crops: Iterable[Mapping[str, Any]]) -> Iterable[tuple[int, Mapping[str, Any]]]:
+    for crop in crops:
+        crop_id = int(crop["id"])
+        for price in crop.get("price_weekly", []) or []:
+            yield crop_id, price
+
+
+def write_crops(conn: sqlite3.Connection, crops: Iterable[Mapping[str, Any]]) -> None:
+    crops_list = list(crops)
+    for crop in crops_list:
+        crop_id = int(crop["id"])
+        name = crop["name"]
+        category = crop["category"]
+        conn.execute(
+            "INSERT OR IGNORE INTO crops (id, name, category) VALUES (?, ?, ?)",
+            (crop_id, name, category),
+        )
+        conn.execute(
+            "UPDATE crops SET name = ?, category = ? WHERE id = ?",
+            (name, category, crop_id),
+        )
+
+    for crop_id, price in _iter_price_records(crops_list):
+        week_value = price["week"]
+        if isinstance(week_value, int):
+            week_iso = utils_week.iso_week_from_int(int(week_value))
+        else:
+            week_iso = str(week_value)
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO price_weekly (
+                crop_id, week, avg_price, stddev, unit, source
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """.strip(),
+            (
+                crop_id,
+                week_iso,
+                _optional_float(price.get("price")),
+                _optional_float(price.get("stddev")),
+                price.get("unit", "円/kg"),
+                price.get("source", "seed"),
+            ),
+        )
+
+
+def write_price_samples(conn: sqlite3.Connection, price_samples: Iterable[Mapping[str, Any]]) -> None:
+    for row in price_samples:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO price_weekly (
+                crop_id, week, avg_price, stddev, unit, source
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """.strip(),
+            (
+                int(row["crop_id"]),
+                str(row["week"]),
+                _optional_float(row.get("avg_price")),
+                _optional_float(row.get("stddev")),
+                row.get("unit", "円/kg"),
+                row.get("source", "seed"),
+            ),
+        )
+
+
+def write_growth_days(conn: sqlite3.Connection, growth_days: Iterable[Mapping[str, Any]]) -> None:
+    for entry in growth_days:
+        crop_id = int(entry["crop_id"])
+        region = entry["region"]
+        days = int(entry["days"])
+        conn.execute(
+            "INSERT OR IGNORE INTO growth_days (crop_id, region, days) VALUES (?, ?, ?)",
+            (crop_id, region, days),
+        )
+        conn.execute(
+            "UPDATE growth_days SET days = ? WHERE crop_id = ? AND region = ?",
+            (days, crop_id, region),
+        )
+
+
+def write_seed_payload(
+    conn: sqlite3.Connection,
+    *,
+    crops: Iterable[Mapping[str, Any]],
+    price_samples: Iterable[Mapping[str, Any]],
+    growth_days: Iterable[Mapping[str, Any]],
+) -> None:
+    write_crops(conn, crops)
+    write_price_samples(conn, price_samples)
+    write_growth_days(conn, growth_days)
+
+
+__all__ = [
+    "write_crops",
+    "write_price_samples",
+    "write_growth_days",
+    "write_seed_payload",
+]

--- a/backend/tests/test_seed_data.py
+++ b/backend/tests/test_seed_data.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import seed as seed_module
+from app.seed import data_loader
+from app.utils_week import iso_week_from_int
+
+
+@pytest.fixture
+def seed_payload() -> data_loader.SeedPayload:
+    return data_loader.SeedPayload(
+        crops=[
+            {
+                "id": 1,
+                "name": "Lettuce",
+                "category": "Leafy",
+                "price_weekly": [
+                    {
+                        "week": 202301,
+                        "price": 120,
+                        "stddev": 5,
+                        "unit": "円/kg",
+                        "source": "survey",
+                    }
+                ],
+            }
+        ],
+        price_samples=[
+            {
+                "crop_id": 2,
+                "week": "2023-W02",
+                "avg_price": 150,
+                "stddev": 10,
+                "unit": "円/kg",
+                "source": "seed",
+            }
+        ],
+        growth_days=[
+            {"crop_id": 1, "region": "tokyo", "days": 65},
+        ],
+    )
+
+
+def test_seed_inserts_expected_records(monkeypatch: pytest.MonkeyPatch, seed_payload: data_loader.SeedPayload) -> None:
+    monkeypatch.setattr(seed_module.db, "init_db", lambda conn: None)
+    monkeypatch.setattr(seed_module, "load_seed_payload", lambda data_dir=None: seed_payload)
+
+    conn = MagicMock()
+
+    seed_module.seed(conn=conn)
+
+    executed = [call.args for call in conn.execute.call_args_list]
+
+    assert (
+        "INSERT OR IGNORE INTO crops (id, name, category) VALUES (?, ?, ?)",
+        (1, "Lettuce", "Leafy"),
+    ) in executed
+    assert ("UPDATE crops SET name = ?, category = ? WHERE id = ?", ("Lettuce", "Leafy", 1)) in executed
+
+    assert any(
+        sql.startswith("INSERT OR REPLACE INTO price_weekly")
+        and params
+        == (
+            1,
+            iso_week_from_int(202301),
+            120.0,
+            5.0,
+            "円/kg",
+            "survey",
+        )
+        for sql, params in executed
+    )
+    assert any(
+        sql.startswith("INSERT OR IGNORE INTO price_weekly")
+        and params == (2, "2023-W02", 150.0, 10.0, "円/kg", "seed")
+        for sql, params in executed
+    )
+
+    assert (
+        "INSERT OR IGNORE INTO growth_days (crop_id, region, days) VALUES (?, ?, ?)",
+        (1, "tokyo", 65),
+    ) in executed
+    assert ("UPDATE growth_days SET days = ? WHERE crop_id = ? AND region = ?", (65, 1, "tokyo")) in executed
+
+    conn.commit.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add a regression test that patches seed data loading and asserts crops, price, and growth rows are written
- extract JSON loading utilities into a seed.data_loader module and capture the payload shape with a dataclass
- move insert/update statements into seed.writers and re-export the new entry points via the legacy seed.py shim

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0dd831d688321ba2ced2009971551