### PR TITLE
Support legacy /recommend endpoint

### DIFF
--- a/backend/app/routes/recommend.py
+++ b/backend/app/routes/recommend.py
@@ -5,10 +5,12 @@ from fastapi import APIRouter, HTTPException
 from .. import schemas, utils_week
 from ..dependencies import ConnDependency, RecommendRegionQuery, RecommendWeekQuery
 
-router = APIRouter(prefix="/api/recommend")
+router = APIRouter()
 
 
-@router.get("", response_model=schemas.RecommendResponse)
+# NOTE: keep both legacy "/recommend" and current "/api/recommend" paths wired to this handler.
+@router.get("/api/recommend", response_model=schemas.RecommendResponse)
+@router.get("/recommend", response_model=schemas.RecommendResponse)
 def recommend(
     week: RecommendWeekQuery = None,
     region: RecommendRegionQuery = schemas.DEFAULT_REGION,

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -94,3 +94,12 @@ def test_recommend_ignores_price_sources_for_metadata() -> None:
 
     sources = {item["source"] for item in items}
     assert sources == {"internal"}
+
+
+def test_recommend_legacy_path_returns_same_payload() -> None:
+    api_response = client.get("/api/recommend", params={"week": REFERENCE_WEEK})
+    legacy_response = client.get("/recommend", params={"week": REFERENCE_WEEK})
+
+    assert api_response.status_code == 200
+    assert legacy_response.status_code == 200
+    assert legacy_response.json() == api_response.json()


### PR DESCRIPTION
## Summary
- add a regression test ensuring the legacy `/recommend` endpoint mirrors `/api/recommend`
- expose the recommend handler on both `/api/recommend` and `/recommend`, documenting the legacy path requirement

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0dd82f43883218bf676fcd2a587cb