### PR TITLE
Ensure recommendation active week stays on invalid response

### DIFF
--- a/frontend/src/hooks/useRecommendations.test.ts
+++ b/frontend/src/hooks/useRecommendations.test.ts
@@ -107,6 +107,27 @@ describe('useRecommendationLoader', () => {
     expect(fetchRecommendationsMock).toHaveBeenCalledWith('temperate', '2024-W53')
   })
 
+  it('API が不正な週を返した場合でも activeWeek はリクエスト週を保持する', async () => {
+    const { result } = renderHook(() => useRecommendationLoader('temperate'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    fetchRecommendationsMock.mockClear()
+    fetchRecommendationsMock.mockImplementationOnce(async () => ({
+      week: 'invalid',
+      region: 'temperate',
+      items: [],
+    }))
+
+    await act(async () => {
+      await result.current.requestRecommendations('2024-W10')
+    })
+
+    expect(result.current.activeWeek).toBe('2024-W10')
+  })
+
   it('並列実行時に古いリクエスト結果を無視する', async () => {
     const initial = createDeferred<RecommendResponse>()
     const first = createDeferred<RecommendResponse>()

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -183,7 +183,7 @@ export const useRecommendationLoader = (region: Region): UseRecommendationLoader
           currentWeekRef.current = normalizedWeek
           return
         }
-        const resolvedWeek = normalizeWeek(result.week)
+        const resolvedWeek = normalizeIsoWeek(result.week, normalizedWeek)
         setItems(result.items)
         setActiveWeek(resolvedWeek)
         currentWeekRef.current = resolvedWeek


### PR DESCRIPTION
## Summary
- add coverage ensuring activeWeek remains on the requested week when the API responds with an invalid value
- normalize recommendation responses using the current request week as fallback to avoid reverting to stale weeks

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0e450eed08321a5ef3bfb00c88a27