### PR TITLE
Add ETL smoke test coverage for migrated modules

### DIFF
--- a/backend/tests/test_etl.py
+++ b/backend/tests/test_etl.py
@@ -3,15 +3,14 @@
 All assertions have moved under ``backend/tests/etl`` to ease maintenance.
 This module remains importable for downstream references until the checklist
 below is fully checked and the shim can be removed.
-
-Checklist:
-- [x] etl/test_connection.py へ移行完了
-- [x] etl/test_schema.py へ移行完了
-- [x] etl/test_runner.py へ移行完了
-- [x] etl/test_retry.py へ移行完了
 """
 
 from __future__ import annotations
+
+# TODO [x] etl/test_connection.py へ移行完了
+# TODO [x] etl/test_schema.py へ移行完了
+# TODO [x] etl/test_runner.py へ移行完了
+# TODO [x] etl/test_retry.py へ移行完了
 
 from .etl import test_connection as _test_connection
 from .etl import test_retry as _test_retry

--- a/backend/tests/test_etl_smoke.py
+++ b/backend/tests/test_etl_smoke.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import inspect
+from importlib import import_module
+import pkgutil
+from types import ModuleType
+
+ETL_PACKAGE = ".etl"
+_HELPER_MODULE_SUFFIXES = {"._helpers"}
+
+
+def _iter_etl_modules() -> list[str]:
+    package = import_module(ETL_PACKAGE, package=__package__)
+    prefix = f"{package.__name__}."
+    module_names: list[str] = []
+    for _, name, _ in pkgutil.iter_modules(package.__path__, prefix):
+        if any(name.endswith(suffix) for suffix in _HELPER_MODULE_SUFFIXES):
+            continue
+        module_names.append(name)
+    return module_names
+
+
+def _has_collectable_tests(module: ModuleType) -> bool:
+    if any(name.startswith("test_") and callable(obj) for name, obj in inspect.getmembers(module)):
+        return True
+    if any(name.startswith("Test") and inspect.isclass(obj) for name, obj in inspect.getmembers(module)):
+        return True
+    return False
+
+
+def test_etl_package_modules_have_collectable_tests() -> None:
+    missing: list[str] = []
+    for module_name in _iter_etl_modules():
+        module = import_module(module_name)
+        if not _has_collectable_tests(module):
+            missing.append(module_name)
+    assert not missing, f"missing pytest tests in: {', '.join(missing)}"


### PR DESCRIPTION
## Summary
- add a smoke test that imports ETL test modules and asserts they expose pytest-compatible tests
- annotate the legacy backend/tests/test_etl.py shim with TODO checklist markers for the migrated modules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0f1864c508321947682a1a78c10d5