### PR TITLE
Fix fetchRecommend URL prefix handling

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -34,7 +34,7 @@ describe('fetchRecommend', () => {
     const result = await fetchRecommend({ region: 'temperate', week: '2024-W30' })
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/recommend?region=temperate&week=2024-W30',
+      '/recommend?region=temperate&week=2024-W30',
       {
         headers: { 'Content-Type': 'application/json' },
       },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,10 +9,19 @@ import type {
 
 const API_ENDPOINT = (import.meta.env.VITE_API_ENDPOINT ?? '/api').replace(/\/$/, '')
 
-const buildUrl = (path: string, searchParams?: URLSearchParams): string => {
+type BuildUrlOptions = {
+  readonly includePrefix?: boolean
+}
+
+const buildUrl = (
+  path: string,
+  searchParams?: URLSearchParams,
+  options?: BuildUrlOptions,
+): string => {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   const search = searchParams?.toString()
-  return `${API_ENDPOINT}${normalizedPath}${search ? `?${search}` : ''}`
+  const prefix = options?.includePrefix === false ? '' : API_ENDPOINT
+  return `${prefix}${normalizedPath}${search ? `?${search}` : ''}`
 }
 
 const request = async <T>(input: RequestInfo, init?: RequestInit): Promise<T> => {
@@ -63,7 +72,7 @@ export const fetchRecommend = async ({
   if (week) {
     params.set('week', week)
   }
-  const url = buildUrl('/recommend', params)
+  const url = buildUrl('/recommend', params, { includePrefix: false })
   return request<RecommendResponse>(url)
 }
 


### PR DESCRIPTION
## Summary
- update the fetchRecommend test to expect a relative /recommend URL when the API prefix is mocked
- extend buildUrl to optionally omit the API prefix and apply it to fetchRecommend while leaving fetchRecommendations unchanged

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0f184d5c083218062e87cf1415eeb