### PR TITLE
Refactor crop catalog handling in recommendations hook

### DIFF
--- a/frontend/src/hooks/useCropCatalog.ts
+++ b/frontend/src/hooks/useCropCatalog.ts
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import * as apiModule from '../lib/api'
+import type { Crop } from '../types'
+
+const api = apiModule as typeof import('../lib/api') & {
+  fetchCrops?: () => Promise<Crop[]>
+}
+
+export interface CropCatalogEntry {
+  id: number
+  name: string
+  category: string
+}
+
+export type CropCatalogMap = Map<string, CropCatalogEntry>
+
+export interface UseCropCatalogResult {
+  catalog: CropCatalogMap
+  isLoading: boolean
+}
+
+const fetchCrops = api.fetchCrops
+
+export const useCropCatalog = (): UseCropCatalogResult => {
+  const [crops, setCrops] = useState<Crop[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    let active = true
+    const load = async () => {
+      if (typeof fetchCrops !== 'function') {
+        if (active) {
+          setCrops([])
+          setIsLoading(false)
+        }
+        return
+      }
+      try {
+        setIsLoading(true)
+        const response = await fetchCrops()
+        if (active) {
+          setCrops(response)
+        }
+      } catch {
+        if (active) {
+          setCrops([])
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false)
+        }
+      }
+    }
+    void load()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const catalog = useMemo<CropCatalogMap>(() => {
+    const map: CropCatalogMap = new Map()
+    crops.forEach((crop) => {
+      map.set(crop.name, {
+        id: crop.id,
+        name: crop.name,
+        category: crop.category,
+      })
+    })
+    return map
+  }, [crops])
+
+  return { catalog, isLoading }
+}


### PR DESCRIPTION
## Summary
- add a dedicated useCropCatalog hook that loads crop metadata into a reusable map with loading state
- refactor useRecommendations to depend on the centralized catalog and re-export the hook and related types

## Testing
- npm run typecheck
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e10391285883219a4ac2f1b6dce267