### PR TITLE
Improve search controls layout and toast presentation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -35,6 +35,21 @@ body {
 .app__controls {
   display: flex;
   gap: 0.75rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.app__controls-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+  flex: 1;
+  min-width: 260px;
+}
+
+.app__controls-actions {
+  display: flex;
+  gap: 0.5rem;
   align-items: center;
 }
 
@@ -46,6 +61,11 @@ body {
   color: #fff;
   font-weight: 600;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  position: relative;
 }
 
 .app__refresh:hover {
@@ -55,6 +75,25 @@ body {
 .app__refresh:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.app__refresh--loading::before {
+  content: '';
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  animation: app-refresh-spin 0.75s linear infinite;
+}
+
+@keyframes app-refresh-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .region-select {
@@ -73,6 +112,20 @@ body {
   border-radius: 0.5rem;
   border: 1px solid #c5d6c3;
   background-color: #fff;
+}
+
+.app__week {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.app__week input {
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid #c5d6c3;
 }
 
 .recommend__meta {
@@ -162,4 +215,86 @@ body {
 
 .fav-star:hover {
   color: #fbc02d;
+}
+
+.toast-stack {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 1000;
+}
+
+.toast {
+  min-width: 260px;
+  max-width: 360px;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+  background-color: #1f2937;
+  color: #f9fafb;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.toast--info {
+  background-color: #2563eb;
+}
+
+.toast--success {
+  background-color: #16a34a;
+}
+
+.toast--warning {
+  background-color: #d97706;
+}
+
+.toast--error {
+  background-color: #dc2626;
+}
+
+@media (max-width: 640px) {
+  .app__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .app__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app__controls-group {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 0.5rem;
+  }
+
+  .app__controls-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .app__controls-actions button {
+    width: 100%;
+  }
+
+  .toast-stack {
+    top: 1rem;
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+  }
+
+  .toast {
+    max-width: none;
+    width: 100%;
+  }
 }

--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -25,30 +25,34 @@ export const SearchControls = ({
   return (
     <form className="app__controls" onSubmit={onSubmit} noValidate>
       <RegionSelect onChange={onRegionChange} />
-      <label className="app__week" htmlFor="week-input">
-        週
-        <input
-          id="week-input"
-          name="week"
-          type="text"
-          value={queryWeek}
-          onChange={onWeekChange}
-          placeholder={currentWeek}
-          pattern="\d{4}-W\d{2}"
-          inputMode="numeric"
-        />
-      </label>
-      <button type="submit">この条件で見る</button>
-      <button
-        className="app__refresh"
-        type="button"
-        onClick={() => {
-          void onRefresh()
-        }}
-        disabled={refreshing}
-      >
-        更新
-      </button>
+      <div className="app__controls-group">
+        <label className="app__week" htmlFor="week-input">
+          週
+          <input
+            id="week-input"
+            name="week"
+            type="text"
+            value={queryWeek}
+            onChange={onWeekChange}
+            placeholder={currentWeek}
+            pattern="\d{4}-W\d{2}"
+            inputMode="numeric"
+          />
+        </label>
+        <div className="app__controls-actions">
+          <button type="submit">この条件で見る</button>
+          <button
+            className={`app__refresh${refreshing ? ' app__refresh--loading' : ''}`}
+            type="button"
+            onClick={() => {
+              void onRefresh()
+            }}
+            disabled={refreshing}
+          >
+            {refreshing ? '更新中...' : '更新'}
+          </button>
+        </div>
+      </div>
     </form>
   )
 }

--- a/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
+++ b/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
@@ -47,32 +47,40 @@ exports[`App snapshot > 初期表示をスナップショット保存する 1`] 
             </option>
           </select>
         </label>
-        <label
-          class="app__week"
-          for="week-input"
+        <div
+          class="app__controls-group"
         >
-          週
-          <input
-            id="week-input"
-            inputmode="numeric"
-            name="week"
-            pattern="\\d{4}-W\\d{2}"
-            placeholder="2024-W30"
-            type="text"
-            value="2024-W30"
-          />
-        </label>
-        <button
-          type="submit"
-        >
-          この条件で見る
-        </button>
-        <button
-          class="app__refresh"
-          type="button"
-        >
-          更新
-        </button>
+          <label
+            class="app__week"
+            for="week-input"
+          >
+            週
+            <input
+              id="week-input"
+              inputmode="numeric"
+              name="week"
+              pattern="\\d{4}-W\\d{2}"
+              placeholder="2024-W30"
+              type="text"
+              value="2024-W30"
+            />
+          </label>
+          <div
+            class="app__controls-actions"
+          >
+            <button
+              type="submit"
+            >
+              この条件で見る
+            </button>
+            <button
+              class="app__refresh"
+              type="button"
+            >
+              更新
+            </button>
+          </div>
+        </div>
       </form>
     </header>
     <main


### PR DESCRIPTION
## Summary
- group the search controls to support responsive stacking and add a loading state on the refresh button
- add toast stack styling with responsive behavior and Tailwind-inspired palette
- update snapshot to reflect the new markup structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1038f033883218e61db244440a326