### PR TITLE
Add UI-facing search filter and refresh status types

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,7 @@ export interface Crop {
   id: number
   name: string
   category: string
+  variety?: string
 }
 
 /** 作物の生育期間メタデータ */
@@ -36,16 +37,26 @@ export interface RecommendResponse {
   items: RecommendationItem[]
 }
 
+export type RefreshState = 'success' | 'failure' | 'running' | 'stale'
+
 export interface RefreshResponse {
-  state: 'success' | 'failure' | 'running' | 'stale'
+  state: RefreshState
 }
 
 export interface RefreshStatusResponse {
-  state: 'success' | 'failure' | 'running' | 'stale'
+  state: RefreshState
   started_at: string | null
   finished_at: string | null
   updated_records: number
   last_error: string | null
+}
+
+export interface RefreshStatus {
+  state: RefreshState
+  startedAt: string | null
+  finishedAt: string | null
+  updatedRecords: number
+  lastError: string | null
 }
 
 export interface RegionOption {
@@ -75,4 +86,8 @@ export interface RegionStorage {
 /** お気に入り作物IDを保存するストレージ構造 */
 export interface FavoritesStorage {
   favorites: number[]
+}
+
+export interface SearchFilter {
+  keyword: string
 }

--- a/frontend/tests/types.test.ts
+++ b/frontend/tests/types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type {
+  Crop,
+  RefreshStatus,
+  RefreshStatusResponse,
+  SearchFilter,
+} from '../src/types'
+
+describe('type definitions', () => {
+  it('SearchFilter はキーワード文字列を保持する', () => {
+    expectTypeOf<SearchFilter>().toMatchTypeOf<{ keyword: string }>()
+  })
+
+  it('Crop は variety プロパティをオプションで受け取れる', () => {
+    expectTypeOf<Crop>().toMatchTypeOf<{ variety?: string }>()
+  })
+
+  it('RefreshStatus は UI 仕様のフィールド名を提供する', () => {
+    expectTypeOf<RefreshStatus>().toMatchTypeOf<{
+      state: 'success' | 'failure' | 'running' | 'stale'
+      startedAt: string | null
+      finishedAt: string | null
+      updatedRecords: number
+      lastError: string | null
+    }>()
+  })
+
+  it('RefreshStatusResponse は API 応答のスネークケースフィールドを保持する', () => {
+    expectTypeOf<RefreshStatusResponse>().toMatchTypeOf<{
+      state: 'success' | 'failure' | 'running' | 'stale'
+      started_at: string | null
+      finished_at: string | null
+      updated_records: number
+      last_error: string | null
+    }>()
+  })
+})


### PR DESCRIPTION
## Summary
- extend frontend type definitions with SearchFilter, RefreshState, and RefreshStatus without breaking existing API shapes
- allow Crop entries to carry optional variety metadata in anticipation of catalog expansion
- add vitest coverage that locks down the SearchFilter, Crop, and refresh status typings

## Testing
- npm run typecheck
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e1038db96c8321813cdc1f1930ed62