### PR TITLE
Add crop search filter coverage and UI support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,18 @@ export const App = () => {
 
   const initialRegionRef = useRef<Region>(loadRegion())
 
-  const { region, setRegion, queryWeek, setQueryWeek, currentWeek, displayWeek, sortedRows, handleSubmit } =
+  const {
+    region,
+    setRegion,
+    queryWeek,
+    setQueryWeek,
+    searchQuery,
+    setSearchQuery,
+    currentWeek,
+    displayWeek,
+    sortedRows,
+    handleSubmit,
+  } =
     useRecommendations({ favorites, initialRegion: initialRegionRef.current })
 
   const handleWeekChange = useCallback(
@@ -36,6 +47,13 @@ export const App = () => {
       setRegion(next)
     },
     [setRegion],
+  )
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchQuery(value)
+    },
+    [setSearchQuery],
   )
 
   const handleRefresh = useCallback(async () => {
@@ -65,6 +83,8 @@ export const App = () => {
           onSubmit={handleSubmit}
           onRefresh={handleRefresh}
           refreshing={refreshing}
+          searchQuery={searchQuery}
+          onSearchChange={handleSearchChange}
         />
       </header>
       <main className="app__main">

--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -11,6 +11,8 @@ interface SearchControlsProps {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   onRefresh: () => void | Promise<void>
   refreshing: boolean
+  searchQuery: string
+  onSearchChange: (value: string) => void
 }
 
 export const SearchControls = ({
@@ -21,10 +23,25 @@ export const SearchControls = ({
   onSubmit,
   onRefresh,
   refreshing,
+  searchQuery,
+  onSearchChange,
 }: SearchControlsProps) => {
   return (
     <form className="app__controls" onSubmit={onSubmit} noValidate>
       <RegionSelect onChange={onRegionChange} />
+      <label className="app__search" htmlFor="crop-search">
+        作物検索
+        <input
+          id="crop-search"
+          type="search"
+          value={searchQuery}
+          placeholder="作物名・カテゴリで検索"
+          aria-label="作物検索"
+          onChange={(event) => {
+            onSearchChange(event.target.value)
+          }}
+        />
+      </label>
       <label className="app__week" htmlFor="week-input">
         週
         <input

--- a/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
+++ b/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
@@ -48,6 +48,19 @@ exports[`App snapshot > 初期表示をスナップショット保存する 1`] 
           </select>
         </label>
         <label
+          class="app__search"
+          for="crop-search"
+        >
+          作物検索
+          <input
+            aria-label="作物検索"
+            id="crop-search"
+            placeholder="作物名・カテゴリで検索"
+            type="search"
+            value=""
+          />
+        </label>
+        <label
           class="app__week"
           for="week-input"
         >

--- a/frontend/tests/forms/weekInput.test.tsx
+++ b/frontend/tests/forms/weekInput.test.tsx
@@ -18,6 +18,8 @@ describe('Week form interactions', () => {
       setRegion: vi.fn(),
       queryWeek: '2024-W30',
       setQueryWeek,
+      searchQuery: '',
+      setSearchQuery: vi.fn(),
       currentWeek: '2024-W30',
       displayWeek: '2024-W30',
       sortedRows: [],

--- a/frontend/tests/recommendations/searchFilter.test.tsx
+++ b/frontend/tests/recommendations/searchFilter.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, type MockInstance } from 'vitest'
+
+import {
+  fetchCrops,
+  fetchRecommend,
+  fetchRecommendations,
+  renderApp,
+  resetAppSpies,
+  storageState,
+} from '../utils/renderApp'
+import {
+  createRecommendResponse,
+  createSearchFilterFixtures,
+  setupRecommendationsTest,
+} from '../utils/recommendations'
+
+describe('App recommendations / 検索フィルタ', () => {
+  let useRecommendationsSpy: MockInstance
+
+  beforeEach(async () => {
+    resetAppSpies()
+    fetchRecommend.mockRejectedValue(new Error('legacy endpoint disabled'))
+    ;({ useRecommendationsSpy } = await setupRecommendationsTest())
+  })
+
+  afterEach(() => {
+    cleanup()
+    useRecommendationsSpy.mockRestore()
+    resetAppSpies()
+  })
+
+  it('名前・カテゴリ・正規化・大文字小文字・お気に入り優先が検索に反映される', async () => {
+    const fixtures = createSearchFilterFixtures()
+    storageState.favorites = [...fixtures.favorites]
+    fetchCrops.mockResolvedValue(fixtures.crops)
+    fetchRecommendations.mockResolvedValue(
+      createRecommendResponse({ items: fixtures.items }),
+    )
+
+    const { user } = await renderApp()
+
+    const table = await screen.findByRole('table')
+    const searchInput = screen.getByRole('searchbox', { name: '作物検索' })
+
+    await waitFor(() => {
+      fixtures.items.forEach((item) => {
+        expect(table).toHaveTextContent(item.crop)
+      })
+    })
+
+    const expectRows = async (names: string[]) => {
+      await waitFor(() => {
+        const rows = within(table).getAllByRole('row').slice(1)
+        expect(rows).toHaveLength(names.length)
+        rows.forEach((row, index) => {
+          expect(row).toHaveTextContent(names[index] ?? '')
+        })
+      })
+    }
+
+    await user.clear(searchInput)
+    await user.type(searchInput, fixtures.queries.name)
+    await expectRows(['春菊'])
+
+    await user.clear(searchInput)
+    await user.type(searchInput, fixtures.queries.category)
+    await expectRows(['コスモス'])
+
+    await user.clear(searchInput)
+    await user.type(searchInput, fixtures.queries.nfkc)
+    await expectRows(['ミツバ'])
+
+    await user.clear(searchInput)
+    await user.type(searchInput, fixtures.queries.caseInsensitive)
+    await expectRows(['Basil'])
+
+    await user.clear(searchInput)
+    await user.type(searchInput, fixtures.queries.favoriteCategory)
+    await expectRows(fixtures.expected.favoriteOrder)
+  })
+})

--- a/frontend/tests/utils/recommendations.ts
+++ b/frontend/tests/utils/recommendations.ts
@@ -11,6 +11,7 @@ export const defaultCrops = [
   { id: 1, name: '春菊', category: 'leaf' },
   { id: 2, name: 'にんじん', category: 'root' },
   { id: 3, name: 'キャベツ', category: 'leaf' },
+  { id: 4, name: 'コスモス', category: 'flower' },
 ] as const
 
 export const createRecommendResponse = (
@@ -46,4 +47,56 @@ export const setupRecommendationsTest = async (): Promise<SetupRecommendationsTe
   )
   const useRecommendationsSpy = vi.spyOn(useRecommendationsModule, 'useRecommendations')
   return { useRecommendationsModule, useRecommendationsSpy }
+}
+
+interface SearchFilterFixtures {
+  crops: { id: number; name: string; category: string }[]
+  items: RecommendationItem[]
+  favorites: number[]
+  queries: {
+    name: string
+    category: string
+    nfkc: string
+    caseInsensitive: string
+    favoriteCategory: string
+  }
+  expected: {
+    favoriteOrder: string[]
+  }
+}
+
+export const createSearchFilterFixtures = (): SearchFilterFixtures => {
+  const crops = [
+    { id: 1, name: '春菊', category: 'leaf' },
+    { id: 2, name: 'にんじん', category: 'root' },
+    { id: 3, name: 'キャベツ', category: 'leaf' },
+    { id: 4, name: 'コスモス', category: 'flower' },
+    { id: 5, name: 'Basil', category: 'herb' },
+    { id: 6, name: 'ミツバ', category: 'leaf' },
+  ]
+
+  const items = [
+    createItem({ crop: '春菊', sowing_week: '2024-W19', harvest_week: '2024-W30', source: 'leaf-db' }),
+    createItem({ crop: 'にんじん', sowing_week: '2024-W22', harvest_week: '2024-W40', source: 'root-db' }),
+    createItem({ crop: 'キャベツ', sowing_week: '2024-W21', harvest_week: '2024-W35', source: 'leaf-db' }),
+    createItem({ crop: 'コスモス', sowing_week: '2024-W24', harvest_week: '2024-W36', source: 'flower-db' }),
+    createItem({ crop: 'Basil', sowing_week: '2024-W23', harvest_week: '2024-W33', source: 'herb-db' }),
+    createItem({ crop: 'ミツバ', sowing_week: '2024-W18', harvest_week: '2024-W26', source: 'leaf-db' }),
+  ]
+
+  return {
+    crops,
+    items,
+    favorites: [6],
+    queries: {
+      name: '春菊',
+      category: 'flower',
+      nfkc: 'ﾐﾂﾊﾞ',
+      caseInsensitive: 'bASIL',
+      favoriteCategory: 'leaf',
+    },
+    expected: {
+      favoriteOrder: ['ミツバ', '春菊', 'キャベツ'],
+    },
+  }
 }


### PR DESCRIPTION
## Summary
- extend test fixtures with flower crops and reusable search filter data
- add recommendation search filter interaction test covering normalization and favorites priority
- expose crop search input and filtering logic so the UI responds to text queries

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e10390b6c8832181d52e820d421cef