### PR TITLE
Fix fetchRecommend fallback for absolute API endpoints

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,7 +12,7 @@ const API_ENDPOINT = (import.meta.env.VITE_API_ENDPOINT ?? '/api').replace(/\/$/
 const API_ENDPOINT_URL = (() => {
   try {
     return new URL(API_ENDPOINT)
-  } catch (error) {
+  } catch {
     return undefined
   }
 })()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,19 @@ import type {
 
 const API_ENDPOINT = (import.meta.env.VITE_API_ENDPOINT ?? '/api').replace(/\/$/, '')
 
+const API_ENDPOINT_URL = (() => {
+  try {
+    return new URL(API_ENDPOINT)
+  } catch (error) {
+    return undefined
+  }
+})()
+
+const API_ENDPOINT_ORIGIN = API_ENDPOINT_URL?.origin ?? ''
+const API_ENDPOINT_PREFIX = API_ENDPOINT_URL
+  ? `${API_ENDPOINT_ORIGIN}${API_ENDPOINT_URL.pathname.replace(/\/$/, '')}`
+  : API_ENDPOINT
+
 type BuildUrlOptions = {
   readonly includePrefix?: boolean
 }
@@ -20,7 +33,7 @@ const buildUrl = (
 ): string => {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   const search = searchParams?.toString()
-  const prefix = options?.includePrefix === false ? '' : API_ENDPOINT
+  const prefix = options?.includePrefix === false ? API_ENDPOINT_ORIGIN : API_ENDPOINT_PREFIX
   return `${prefix}${normalizedPath}${search ? `?${search}` : ''}`
 }
 


### PR DESCRIPTION
## Summary
- add a regression test ensuring fetchRecommend falls back to the recommend path even when VITE_API_ENDPOINT is absolute
- adjust buildUrl to preserve the API endpoint origin when includePrefix is false
- reload the API module per test to reflect per-case endpoint overrides

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e10ed45fd48321bd64eaa71af43f14