### PR TITLE
Refactor recommendation loader hook

### DIFF
--- a/frontend/src/hooks/useRecommendationLoader.ts
+++ b/frontend/src/hooks/useRecommendationLoader.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import * as weekModule from '../lib/week'
+import type { RecommendationItem, Region } from '../types'
+import { DEFAULT_ACTIVE_WEEK, DEFAULT_WEEK } from '../utils/recommendations'
+
+import { useRecommendationFetcher } from './recommendationFetcher'
+
+const week = weekModule as typeof import('../lib/week')
+const { normalizeIsoWeek, getCurrentIsoWeek } = week
+type RequestMeta = { id: number; region: Region; week: string }
+type RequestOptions = { preferLegacy?: boolean; regionOverride?: Region }
+const normalizeWeekInput = (value: string, activeWeek: string): string => {
+  const trimmed = value.trim()
+  if (trimmed) {
+    const dateLike = trimmed.match(/^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})$/)
+    if (dateLike) {
+      const [, yearPart, , monthPart, dayPart] = dateLike
+      const year = Number(yearPart)
+      const month = Number(monthPart)
+      const day = Number(dayPart)
+      if (
+        Number.isInteger(year) &&
+        Number.isInteger(month) &&
+        Number.isInteger(day) &&
+        month >= 1 &&
+        month <= 12 &&
+        day >= 1 &&
+        day <= 31
+      ) {
+        const utcDate = new Date(Date.UTC(year, month - 1, day))
+        if (
+          utcDate.getUTCFullYear() === year &&
+          utcDate.getUTCMonth() === month - 1 &&
+          utcDate.getUTCDate() === day
+        ) {
+          return getCurrentIsoWeek(utcDate)
+        }
+      }
+    }
+
+    const upper = trimmed.toUpperCase()
+    const weekFirstMatch = upper.match(/^W?(\d{1,2})\D+(\d{4})$/)
+    if (weekFirstMatch) {
+      const weekPart = weekFirstMatch[1]
+      const yearPart = weekFirstMatch[2]
+      if (weekPart && yearPart) return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
+    }
+
+    const digits = upper.replace(/[^0-9]/g, '')
+    if (digits.length >= 5 && digits.length <= 6) {
+      const yearPart = digits.slice(0, 4)
+      const weekPart = digits.slice(4)
+      if (weekPart) return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
+    }
+  }
+  return normalizeIsoWeek(value, activeWeek)
+}
+export interface UseRecommendationLoaderResult {
+  queryWeek: string
+  setQueryWeek: (week: string) => void
+  activeWeek: string
+  items: RecommendationItem[]
+  currentWeek: string
+  requestRecommendations: (
+    inputWeek: string,
+    options?: RequestOptions,
+  ) => Promise<void>
+}
+export const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult => {
+  const [queryWeek, setQueryWeek] = useState(DEFAULT_WEEK)
+  const [activeWeek, setActiveWeek] = useState(DEFAULT_ACTIVE_WEEK)
+  const [items, setItems] = useState<RecommendationItem[]>([])
+  const currentWeekRef = useRef<string>(DEFAULT_WEEK)
+  const initialFetchRef = useRef(false)
+  const trackerRef = useRef<RequestMeta>({ id: 0, region, week: DEFAULT_WEEK })
+  const fetchRecommendations = useRecommendationFetcher()
+  const applyWeek = useCallback(
+    (weekValue: string, nextItems: RecommendationItem[]) => {
+      setItems(nextItems)
+      setActiveWeek(weekValue)
+      currentWeekRef.current = weekValue
+    },
+    [],
+  )
+
+  const normalizeWeek = useCallback(
+    (value: string) => normalizeWeekInput(value, activeWeek),
+    [activeWeek],
+  )
+
+  const requestRecommendations = useCallback(
+    async (inputWeek: string, options?: RequestOptions) => {
+      const targetRegion = options?.regionOverride ?? region
+      const normalizedWeek = normalizeWeek(inputWeek)
+      setQueryWeek(normalizedWeek)
+      currentWeekRef.current = normalizedWeek
+      const requestMeta: RequestMeta = {
+        id: trackerRef.current.id + 1,
+        region: targetRegion,
+        week: normalizedWeek,
+      }
+      trackerRef.current = requestMeta
+      const isLatest = () => {
+        const latest = trackerRef.current
+        return latest.id === requestMeta.id && latest.region === requestMeta.region && latest.week === requestMeta.week
+      }
+      try {
+        const result = await fetchRecommendations({
+          region: targetRegion,
+          week: normalizedWeek,
+          preferLegacy: options?.preferLegacy,
+        })
+        if (!isLatest()) {
+          return
+        }
+        if (!result) {
+          applyWeek(normalizedWeek, [])
+          return
+        }
+        const resolvedWeek = normalizeIsoWeek(result.week, normalizedWeek)
+        applyWeek(resolvedWeek, result.items)
+      } catch {
+        if (!isLatest()) {
+          return
+        }
+        applyWeek(normalizedWeek, [])
+      }
+    },
+    [applyWeek, fetchRecommendations, normalizeWeek, region],
+  )
+
+  useEffect(() => {
+    if (initialFetchRef.current) {
+      return
+    }
+    initialFetchRef.current = true
+    void requestRecommendations(currentWeekRef.current)
+  }, [requestRecommendations])
+
+  return {
+    queryWeek,
+    setQueryWeek,
+    activeWeek,
+    items,
+    currentWeek: currentWeekRef.current,
+    requestRecommendations,
+  }
+}

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -1,21 +1,10 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import * as weekModule from '../lib/week'
-import type { RecommendationItem, Region } from '../types'
-import {
-  DEFAULT_ACTIVE_WEEK,
-  DEFAULT_WEEK,
-  RecommendationRow,
-  buildRecommendationRows,
-  formatWeekLabel,
-} from '../utils/recommendations'
+import type { Region } from '../types'
+import { RecommendationRow, buildRecommendationRows, formatWeekLabel } from '../utils/recommendations'
 
-import { useRecommendationFetcher } from './recommendationFetcher'
+import { useRecommendationLoader } from './useRecommendationLoader'
 import { useCropCatalog } from './useCropCatalog'
-
-const week = weekModule as typeof import('../lib/week')
-
-const { normalizeIsoWeek, getCurrentIsoWeek } = week
 export interface UseRecommendationsOptions {
   favorites: readonly number[]
   initialRegion?: Region
@@ -30,154 +19,6 @@ export interface UseRecommendationsResult {
   displayWeek: string
   sortedRows: RecommendationRow[]
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void
-}
-
-export interface UseRecommendationLoaderResult {
-  queryWeek: string
-  setQueryWeek: (week: string) => void
-  activeWeek: string
-  items: RecommendationItem[]
-  currentWeek: string
-  requestRecommendations: (
-    inputWeek: string,
-    options?: { preferLegacy?: boolean; regionOverride?: Region },
-  ) => Promise<void>
-}
-
-export const useRecommendationLoader = (region: Region): UseRecommendationLoaderResult => {
-  const [queryWeek, setQueryWeek] = useState(DEFAULT_WEEK)
-  const [activeWeek, setActiveWeek] = useState(DEFAULT_ACTIVE_WEEK)
-  const [items, setItems] = useState<RecommendationItem[]>([])
-  const currentWeekRef = useRef<string>(DEFAULT_WEEK)
-  const initialFetchRef = useRef(false)
-  const requestTrackerRef = useRef<{ id: number; region: Region; week: string }>({
-    id: 0,
-    region,
-    week: currentWeekRef.current,
-  })
-  const fetchRecommendationsWithFallback = useRecommendationFetcher()
-
-  const normalizeWeek = useCallback(
-    (value: string) => {
-      const trimmed = value.trim()
-      if (trimmed) {
-        const dateLike = trimmed.match(/^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})$/)
-        if (dateLike) {
-          const [, yearPart, , monthPart, dayPart] = dateLike
-          const year = Number(yearPart)
-          const month = Number(monthPart)
-          const day = Number(dayPart)
-          if (
-            Number.isInteger(year) &&
-            Number.isInteger(month) &&
-            Number.isInteger(day) &&
-            month >= 1 &&
-            month <= 12 &&
-            day >= 1 &&
-            day <= 31
-          ) {
-            const utcDate = new Date(Date.UTC(year, month - 1, day))
-            if (
-              utcDate.getUTCFullYear() === year &&
-              utcDate.getUTCMonth() === month - 1 &&
-              utcDate.getUTCDate() === day
-            ) {
-              return getCurrentIsoWeek(utcDate)
-            }
-          }
-        }
-
-        const upper = trimmed.toUpperCase()
-        const weekFirstMatch = upper.match(/^W?(\d{1,2})\D+(\d{4})$/)
-        if (weekFirstMatch) {
-          const weekPart = weekFirstMatch[1]
-          const yearPart = weekFirstMatch[2]
-          if (weekPart && yearPart) {
-            return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
-          }
-        }
-
-        const digits = upper.replace(/[^0-9]/g, '')
-        if (digits.length === 5 || digits.length === 6) {
-          const year = digits.slice(0, 4)
-          const weekPart = digits.slice(4)
-          if (year && weekPart) {
-            return normalizeIsoWeek(`${year}-W${weekPart.padStart(2, '0')}`, activeWeek)
-          }
-        }
-      }
-      return normalizeIsoWeek(value, activeWeek)
-    },
-    [activeWeek],
-  )
-
-  const requestRecommendations = useCallback(
-    async (
-      inputWeek: string,
-      options?: { preferLegacy?: boolean; regionOverride?: Region },
-    ) => {
-      const targetRegion = options?.regionOverride ?? region
-      const normalizedWeek = normalizeWeek(inputWeek)
-      setQueryWeek(normalizedWeek)
-      currentWeekRef.current = normalizedWeek
-      const requestId = requestTrackerRef.current.id + 1
-      const requestMeta = { id: requestId, region: targetRegion, week: normalizedWeek }
-      requestTrackerRef.current = requestMeta
-      const isLatestRequest = (): boolean => {
-        const latest = requestTrackerRef.current
-        return (
-          latest.id === requestMeta.id &&
-          latest.region === requestMeta.region &&
-          latest.week === requestMeta.week
-        )
-      }
-      try {
-        const result = await fetchRecommendationsWithFallback({
-          region: targetRegion,
-          week: normalizedWeek,
-          preferLegacy: options?.preferLegacy,
-        })
-        if (!isLatestRequest()) {
-          return
-        }
-        if (!result) {
-          setItems([])
-          setActiveWeek(normalizedWeek)
-          currentWeekRef.current = normalizedWeek
-          return
-        }
-        const resolvedWeek = normalizeIsoWeek(result.week, normalizedWeek)
-        setItems(result.items)
-        setActiveWeek(resolvedWeek)
-        currentWeekRef.current = resolvedWeek
-      } catch {
-        if (!isLatestRequest()) {
-          return
-        }
-        setItems([])
-        setActiveWeek(normalizedWeek)
-        currentWeekRef.current = normalizedWeek
-      }
-    },
-    [fetchRecommendationsWithFallback, normalizeWeek, region],
-  )
-
-  useEffect(() => {
-    if (initialFetchRef.current) {
-      return
-    }
-    initialFetchRef.current = true
-    void requestRecommendations(currentWeekRef.current)
-  }, [requestRecommendations])
-
-  return {
-    queryWeek,
-    setQueryWeek,
-    activeWeek,
-    items,
-    currentWeek: currentWeekRef.current,
-    requestRecommendations,
-  }
 }
 
 export const useRecommendations = ({ favorites, initialRegion }: UseRecommendationsOptions): UseRecommendationsResult => {
@@ -268,3 +109,5 @@ export type { RecommendationRow } from '../utils/recommendations'
 export type { RecommendationFetcher } from './recommendationFetcher'
 export { useCropCatalog } from './useCropCatalog'
 export type { CropCatalogEntry, CropCatalogMap, UseCropCatalogResult } from './useCropCatalog'
+export { useRecommendationLoader } from './useRecommendationLoader'
+export type { UseRecommendationLoaderResult } from './useRecommendationLoader'


### PR DESCRIPTION
## Summary
- extract the recommendation loading logic into a dedicated `useRecommendationLoader` hook with week normalization and request tracking
- simplify `useRecommendations` to focus on state orchestration and favorite sorting while re-exporting the loader API for backwards compatibility
- extend hook tests to cover the refactored loader and guard the public API shape of `useRecommendations`

## Testing
- npm run typecheck
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e127a95d9083218e4d12ed26e63988