### PR TITLE
Add keyboard navigation support for recommendations table

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -160,8 +160,19 @@ body {
   background-color: #f1f8e9;
 }
 
+.recommend__row:focus-visible {
+  outline: 3px solid #66bb6a;
+  outline-offset: -3px;
+  background-color: #f1f8e9;
+}
+
 .recommend__row--selected {
   background-color: #e0f2f1;
+}
+
+.recommend__row--selected:focus-visible {
+  background-color: #e0f2f1;
+  outline-color: #26a69a;
 }
 
 .recommend__chart {

--- a/frontend/src/components/RecommendationsTable.tsx
+++ b/frontend/src/components/RecommendationsTable.tsx
@@ -50,6 +50,21 @@ export const RecommendationsTable = ({
                 key={item.rowKey}
                 className={`recommend__row${isSelected ? ' recommend__row--selected' : ''}`}
                 onClick={() => onSelect(item.cropId ?? null)}
+                tabIndex={0}
+                role="row"
+                aria-selected={isSelected}
+                onKeyDown={(event) => {
+                  if (event.defaultPrevented) {
+                    return
+                  }
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    onSelect(item.cropId ?? null)
+                  } else if (event.key === ' ') {
+                    event.preventDefault()
+                    onToggleFavorite(item.cropId)
+                  }
+                }}
               >
                 <td>
                   <div className="recommend__crop">

--- a/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
+++ b/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
@@ -130,7 +130,10 @@ exports[`App snapshot > 初期表示をスナップショット保存する 1`] 
           </thead>
           <tbody>
             <tr
+              aria-selected="false"
               class="recommend__row"
+              role="row"
+              tabindex="0"
             >
               <td>
                 <div
@@ -160,7 +163,10 @@ exports[`App snapshot > 初期表示をスナップショット保存する 1`] 
               </td>
             </tr>
             <tr
+              aria-selected="false"
               class="recommend__row"
+              role="row"
+              tabindex="0"
             >
               <td>
                 <div

--- a/frontend/tests/recommendations/keyboardNavigation.test.tsx
+++ b/frontend/tests/recommendations/keyboardNavigation.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, afterEach, describe, expect, it, type MockInstance } from 'vitest'
+
+import { fetchCrops, fetchRecommendations, renderApp } from '../utils/renderApp'
+import {
+  createItem,
+  createRecommendResponse,
+  defaultCrops,
+  setupRecommendationsTest,
+} from '../utils/recommendations'
+
+const renderRecommendations = async () => {
+  fetchCrops.mockResolvedValue(defaultCrops)
+  fetchRecommendations.mockResolvedValue(
+    createRecommendResponse({
+      items: [
+        createItem({
+          crop: '春菊',
+        }),
+      ],
+    }),
+  )
+
+  const { user } = await renderApp()
+  const table = await screen.findByRole('table')
+  const rows = within(table).getAllByRole('row')
+  const row = rows[1]!
+  return {
+    user,
+    row,
+  }
+}
+
+describe('App recommendations / キーボード操作', () => {
+  let useRecommendationsSpy: MockInstance
+
+  beforeEach(async () => {
+    ;({ useRecommendationsSpy } = await setupRecommendationsTest())
+  })
+
+  afterEach(() => {
+    useRecommendationsSpy.mockRestore()
+    cleanup()
+  })
+
+  it('Enterキーで行を選択できる', async () => {
+    const { user, row } = await renderRecommendations()
+
+    row.focus()
+    expect(row).toHaveAttribute('aria-selected', 'false')
+
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(row).toHaveAttribute('aria-selected', 'true')
+    })
+  })
+
+  it('Spaceキーでお気に入りを切り替えできる', async () => {
+    const { user, row } = await renderRecommendations()
+    const star = within(row).getByRole('button', { name: '春菊をお気に入りに追加' })
+
+    row.focus()
+    expect(star).toHaveAttribute('aria-pressed', 'false')
+
+    await user.keyboard(' ')
+
+    const toggled = await within(row).findByRole('button', { name: '春菊をお気に入りから外す' })
+    expect(toggled).toHaveAttribute('aria-pressed', 'true')
+  })
+})


### PR DESCRIPTION
## Summary
- make recommendation rows keyboard accessible and handle Enter/Space for selection and favorites
- align table row focus-visible styling with hover/selection cues
- cover keyboard interactions with a dedicated test and update existing snapshot

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e127a8b53883219f4a0678554ef548