### PR TITLE
feat: add search filter tests and UI support

### DIFF
--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -8,6 +8,8 @@ interface SearchControlsProps {
   currentWeek: string
   onWeekChange: (event: ChangeEvent<HTMLInputElement>) => void
   onRegionChange: (region: Region) => void
+  searchKeyword: string
+  onSearchChange: (event: ChangeEvent<HTMLInputElement>) => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   onRefresh: () => void | Promise<void>
   refreshing: boolean
@@ -18,6 +20,8 @@ export const SearchControls = ({
   currentWeek,
   onWeekChange,
   onRegionChange,
+  searchKeyword,
+  onSearchChange,
   onSubmit,
   onRefresh,
   refreshing,
@@ -26,6 +30,15 @@ export const SearchControls = ({
     <form className="app__controls" onSubmit={onSubmit} noValidate>
       <RegionSelect onChange={onRegionChange} />
       <div className="app__controls-group">
+        <input
+          id="search-input"
+          name="search"
+          type="search"
+          value={searchKeyword}
+          onChange={onSearchChange}
+          placeholder="作物名・カテゴリで検索"
+          aria-label="作物検索"
+        />
         <label className="app__week" htmlFor="week-input">
           週
           <input

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -187,9 +187,9 @@ export const useRecommendations = ({ favorites, initialRegion }: UseRecommendati
   const regionFetchSkipRef = useRef<Region | null>(null)
   const { catalog: cropCatalog } = useCropCatalog()
   const cropIndex = useMemo(() => {
-    const map = new Map<string, number>()
+    const map = new Map<string, { id: number; category?: string }>()
     cropCatalog.forEach((entry, cropName) => {
-      map.set(cropName, entry.id)
+      map.set(cropName, { id: entry.id, category: entry.category })
     })
     return map
   }, [cropCatalog])

--- a/frontend/src/utils/recommendations.ts
+++ b/frontend/src/utils/recommendations.ts
@@ -9,6 +9,7 @@ const { compareIsoWeek, formatIsoWeek, normalizeIsoWeek } = week
 
 export type RecommendationRow = RecommendationItem & {
   cropId?: number
+  category?: string
   rowKey: string
   sowingWeekLabel: string
   harvestWeekLabel: string
@@ -65,7 +66,7 @@ export const normalizeRecommendationResponse = (
 interface BuildRecommendationRowsArgs {
   items: RecommendationItem[]
   favorites: readonly number[]
-  cropIndex: Map<string, number>
+  cropIndex: Map<string, { id: number; category?: string }>
 }
 
 export const buildRecommendationRows = ({
@@ -75,13 +76,17 @@ export const buildRecommendationRows = ({
 }: BuildRecommendationRowsArgs): RecommendationRow[] => {
   const favoriteSet = new Set(favorites)
   return items
-    .map<RecommendationRow>((item) => ({
-      ...item,
-      cropId: cropIndex.get(item.crop),
-      rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
-      sowingWeekLabel: formatIsoWeek(item.sowing_week),
-      harvestWeekLabel: formatIsoWeek(item.harvest_week),
-    }))
+    .map<RecommendationRow>((item) => {
+      const catalogEntry = cropIndex.get(item.crop)
+      return {
+        ...item,
+        cropId: catalogEntry?.id,
+        category: catalogEntry?.category,
+        rowKey: `${item.crop}-${item.sowing_week}-${item.harvest_week}`,
+        sowingWeekLabel: formatIsoWeek(item.sowing_week),
+        harvestWeekLabel: formatIsoWeek(item.harvest_week),
+      }
+    })
     .sort((a, b) => {
       const aFav = a.cropId !== undefined && favoriteSet.has(a.cropId) ? 1 : 0
       const bFav = b.cropId !== undefined && favoriteSet.has(b.cropId) ? 1 : 0

--- a/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
+++ b/frontend/tests/__snapshots__/app.snapshot.test.tsx.snap
@@ -50,6 +50,14 @@ exports[`App snapshot > 初期表示をスナップショット保存する 1`] 
         <div
           class="app__controls-group"
         >
+          <input
+            aria-label="作物検索"
+            id="search-input"
+            name="search"
+            placeholder="作物名・カテゴリで検索"
+            type="search"
+            value=""
+          />
           <label
             class="app__week"
             for="week-input"

--- a/frontend/tests/recommendations/searchFilter.test.tsx
+++ b/frontend/tests/recommendations/searchFilter.test.tsx
@@ -1,0 +1,92 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, type MockInstance } from 'vitest'
+
+import {
+  fetchCrops,
+  fetchRecommendations,
+  renderApp,
+  storageState,
+} from '../utils/renderApp'
+import {
+  createItem,
+  createRecommendResponse,
+  defaultCrops,
+  setupRecommendationsTest,
+  toFullWidthAscii,
+} from '../utils/recommendations'
+
+describe('App recommendations / 検索フィルタ', () => {
+  let useRecommendationsSpy: MockInstance
+
+  beforeEach(async () => {
+    ;({ useRecommendationsSpy } = await setupRecommendationsTest())
+  })
+
+  afterEach(() => {
+    useRecommendationsSpy.mockRestore()
+    cleanup()
+  })
+
+  it('検索ボックスで名前・カテゴリの部分一致フィルタとお気に入り優先を維持する', async () => {
+    storageState.favorites = [4, 1]
+    fetchCrops.mockResolvedValue(defaultCrops.map((crop) => ({ ...crop })))
+    fetchRecommendations.mockResolvedValue(
+      createRecommendResponse({
+        items: [
+          createItem({ crop: '春菊', sowing_week: '2024-W31', harvest_week: '2024-W40' }),
+          createItem({ crop: 'にんじん', sowing_week: '2024-W32', harvest_week: '2024-W41' }),
+          createItem({ crop: 'キャベツ', sowing_week: '2024-W33', harvest_week: '2024-W42' }),
+          createItem({ crop: 'トルコギキョウ', sowing_week: '2024-W34', harvest_week: '2024-W43' }),
+        ],
+      }),
+    )
+
+    const { user } = await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenCalled()
+    })
+
+    const searchInput = await screen.findByRole('searchbox', { name: '作物検索' })
+    const table = await screen.findByRole('table')
+
+    const getBodyRows = () => within(table).getAllByRole('row').slice(1)
+
+    await waitFor(() => {
+      const rows = getBodyRows()
+      const flowerIndex = rows.findIndex((row) => within(row).queryByText('トルコギキョウ'))
+      const rootIndex = rows.findIndex((row) => within(row).queryByText('にんじん'))
+      expect(flowerIndex).toBeGreaterThanOrEqual(0)
+      expect(rootIndex).toBeGreaterThanOrEqual(0)
+      expect(flowerIndex).toBeLessThan(rootIndex)
+    })
+
+    await user.type(searchInput, '菊')
+
+    await waitFor(() => {
+      const rows = getBodyRows()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('春菊')
+    })
+
+    await user.clear(searchInput)
+    await user.type(searchInput, 'LEA')
+
+    await waitFor(() => {
+      const rows = getBodyRows()
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).toHaveTextContent('春菊')
+      expect(rows[1]).toHaveTextContent('キャベツ')
+    })
+
+    await user.clear(searchInput)
+    await user.type(searchInput, toFullWidthAscii('flower'))
+
+    await waitFor(() => {
+      const rows = getBodyRows()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('トルコギキョウ')
+    })
+  })
+})

--- a/frontend/tests/utils/recommendations.ts
+++ b/frontend/tests/utils/recommendations.ts
@@ -11,7 +11,11 @@ export const defaultCrops = [
   { id: 1, name: '春菊', category: 'leaf' },
   { id: 2, name: 'にんじん', category: 'root' },
   { id: 3, name: 'キャベツ', category: 'leaf' },
+  { id: 4, name: 'トルコギキョウ', category: 'flower' },
 ] as const
+
+export const toFullWidthAscii = (value: string): string =>
+  value.replace(/[!-~]/g, (char) => String.fromCharCode(char.charCodeAt(0) + 0xfee0))
 
 export const createRecommendResponse = (
   overrides: Partial<RecommendResponse> = {},


### PR DESCRIPTION
## Summary
- add flower-category default crop and helper utilities for width normalization in test harness
- implement search box UI and client-side filtering that honors favorites and NFKC normalization
- cover search behaviour with integration test and update snapshot

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e127a7b5148321a47a28a749771e8e