### PR TITLE
Ensure fetchRecommend keeps API endpoint origin

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,6 +33,14 @@ const buildUrl = (
 ): string => {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   const search = searchParams?.toString()
+
+  if (options?.includePrefix === false && API_ENDPOINT_URL) {
+    const url = new URL(API_ENDPOINT_URL.href)
+    url.pathname = normalizedPath
+    url.search = search ?? ''
+    return url.toString()
+  }
+
   const prefix = options?.includePrefix === false ? API_ENDPOINT_ORIGIN : API_ENDPOINT_PREFIX
   return `${prefix}${normalizedPath}${search ? `?${search}` : ''}`
 }


### PR DESCRIPTION
## Summary
- add a regression test that mocks import.meta.env to confirm fetchRecommend keeps the API host when includePrefix is false
- update buildUrl to rebuild the absolute URL from the configured API endpoint while replacing the pathname

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e13a76aad083218f8788c256db45b2