### PR TITLE
Fix normalization of English-prefixed week inputs

### DIFF
--- a/frontend/src/hooks/recommendations/weekNormalization.ts
+++ b/frontend/src/hooks/recommendations/weekNormalization.ts
@@ -40,6 +40,13 @@ export const normalizeWeekInput = (value: string, activeWeek: string): string =>
       if (weekPart && yearPart) return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
     }
 
+    const englishLeadingMatch = upper.match(/^W(?:EEK|KS?)?\D*(\d{1,2})\D+(\d{4})$/)
+    if (englishLeadingMatch) {
+      const weekPart = englishLeadingMatch[1]
+      const yearPart = englishLeadingMatch[2]
+      if (weekPart && yearPart) return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
+    }
+
     const digits = upper.replace(/[^0-9]/g, '')
     if (digits.length >= 5 && digits.length <= 6) {
       const yearPart = digits.slice(0, 4)

--- a/frontend/tests/recommendations/weekNormalization.test.tsx
+++ b/frontend/tests/recommendations/weekNormalization.test.tsx
@@ -53,6 +53,33 @@ describe('App recommendations / 週入力正規化', () => {
     })
   })
 
+  it('英語表現が含まれる形式を 2024-W24 に整形して送信する', async () => {
+    fetchCrops.mockResolvedValue(defaultCrops.slice(0, 2))
+    fetchRecommendations.mockImplementation(async (region, week) => {
+      const resolvedWeek = week ?? '2024-W30'
+      return createRecommendResponse({
+        week: resolvedWeek,
+        region,
+        items: [createItem({ crop: '春菊' })],
+      })
+    })
+
+    const { user } = await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W30')
+    })
+
+    const weekInput = screen.getByLabelText('週')
+    await user.clear(weekInput)
+    await user.type(weekInput, 'Week 24 2024')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W24')
+    })
+  })
+
   it('週番号が1桁の場合もゼロ埋めして送信する', async () => {
     fetchCrops.mockResolvedValue(defaultCrops.slice(0, 2))
     fetchRecommendations.mockImplementation(async (region, week) => {


### PR DESCRIPTION
## Summary
- add a regression test covering "Week 24 2024" normalization for recommendations
- update week normalization to parse English-prefixed week strings before delegating to normalizeIsoWeek

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1497e3788832195ab842377584f5d