### PR TITLE
Add week normalization tests for recommendation loader

### DIFF
--- a/frontend/src/hooks/useRecommendationLoader.test.ts
+++ b/frontend/src/hooks/useRecommendationLoader.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeWeekInput } from './useRecommendationLoader'
+
+describe('normalizeWeekInput', () => {
+  it.each([
+    ['2024-W6', '2024-W06'],
+    ['W6 2024', '2024-W06'],
+    ['2024W06', '2024-W06'],
+    ['2024-07-01', '2024-W27'],
+    ['2024/07/01', '2024-W27'],
+    ['2024.07.01', '2024-W27'],
+  ])('入力 %s は %s へ正規化される', (input, expected) => {
+    expect(normalizeWeekInput(input, '2024-W05')).toBe(expected)
+  })
+
+  it('日付として解釈できない場合は activeWeek を返す', () => {
+    expect(normalizeWeekInput('invalid', '2024-W05')).toBe('2024-W05')
+  })
+})

--- a/frontend/src/hooks/useRecommendationLoader.ts
+++ b/frontend/src/hooks/useRecommendationLoader.ts
@@ -1,2 +1,3 @@
 export { useRecommendationLoader } from './recommendations/loader'
 export type { UseRecommendationLoaderResult } from './recommendations/loader'
+export { normalizeWeekInput } from './recommendations/weekNormalization'


### PR DESCRIPTION
## Summary
- add coverage for normalizeWeekInput handling of diverse inputs
- expose normalizeWeekInput via useRecommendationLoader entrypoint for reuse

## Testing
- npm run --prefix frontend test -- useRecommendationLoader

------
https://chatgpt.com/codex/tasks/task_e_68e1495bcb28832185f6543b2a95d9b6