### PR TITLE
test: ensure favorites prioritization handles polling

### DIFF
--- a/frontend/tests/recommendations/favoritesPrioritization.test.tsx
+++ b/frontend/tests/recommendations/favoritesPrioritization.test.tsx
@@ -67,7 +67,7 @@ describe('App recommendations / お気に入り並び替え', () => {
       last_error: null,
     })
 
-    const { user } = await renderApp()
+    const { user } = await renderApp({ useFakeTimers: true })
 
     expect(fetchRefreshStatus).not.toHaveBeenCalled()
 

--- a/frontend/tests/utils/renderApp.tsx
+++ b/frontend/tests/utils/renderApp.tsx
@@ -87,7 +87,9 @@ export const resetAppSpies = () => {
 
 export const renderApp = async () => {
   const App = (await import('../../src/App')).default
-  const user = userEvent.setup()
+  const user = userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+  })
   render(<App />)
   await waitFor(() => {
     if (!fetchRecommendations.mock.calls.length && !fetchRecommend.mock.calls.length) {

--- a/frontend/tests/utils/renderApp.tsx
+++ b/frontend/tests/utils/renderApp.tsx
@@ -85,11 +85,19 @@ export const resetAppSpies = () => {
   fetchPrice.mockReset()
 }
 
-export const renderApp = async () => {
+interface RenderAppOptions {
+  readonly useFakeTimers?: boolean
+}
+
+export const renderApp = async ({ useFakeTimers = false }: RenderAppOptions = {}) => {
   const App = (await import('../../src/App')).default
-  const user = userEvent.setup({
-    advanceTimers: vi.advanceTimersByTime,
-  })
+  const user = userEvent.setup(
+    useFakeTimers
+      ? {
+          advanceTimers: vi.advanceTimersByTime,
+        }
+      : undefined,
+  )
   render(<App />)
   await waitFor(() => {
     if (!fetchRecommendations.mock.calls.length && !fetchRecommend.mock.calls.length) {


### PR DESCRIPTION
## Summary
- use fake timers in the favorites prioritization test to simulate polling while verifying favorites ordering and interactions
- configure the test render helper to pass the timer advancement hook to user-event

## Testing
- npm run test -- favoritesPrioritization

------
https://chatgpt.com/codex/tasks/task_e_68e149583bbc8321b8befbdefeda74fe