### PR TITLE
Add refresh status hook with polling and tests

### DIFF
--- a/frontend/src/hooks/useRefreshStatus.test.ts
+++ b/frontend/src/hooks/useRefreshStatus.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { RefreshStatusResponse } from '../types'
+
+import { useRefreshStatus } from './useRefreshStatus'
+
+type PostRefreshMock = () => Promise<{ state: 'running' | 'success' | 'failure' | 'stale' }>
+
+type FetchRefreshStatusMock = () => Promise<RefreshStatusResponse>
+
+const { postRefreshMock, fetchRefreshStatusMock } = vi.hoisted(() => ({
+  postRefreshMock: vi.fn<PostRefreshMock>(),
+  fetchRefreshStatusMock: vi.fn<FetchRefreshStatusMock>(),
+}))
+
+vi.mock('../lib/api', () => ({
+  postRefresh: postRefreshMock,
+  fetchRefreshStatus: fetchRefreshStatusMock,
+}))
+
+const createStatus = (state: RefreshStatusResponse['state'], overrides: Partial<RefreshStatusResponse> = {}): RefreshStatusResponse => ({
+  state,
+  started_at: '2024-01-01T00:00:00Z',
+  finished_at: state === 'running' ? null : '2024-01-01T00:10:00Z',
+  updated_records: 42,
+  last_error: null,
+  ...overrides,
+})
+
+describe('useRefreshStatus', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('ポーリング完了時に成功・失敗・タイムアウトのトーストを通知する', async () => {
+    vi.useFakeTimers()
+
+    postRefreshMock.mockResolvedValueOnce({ state: 'running' })
+
+    const responses: RefreshStatusResponse[] = [
+      createStatus('running'),
+      createStatus('success'),
+    ]
+    fetchRefreshStatusMock.mockImplementation(async () => {
+      const next = responses.shift()
+      if (!next) throw new Error('no status')
+      return next
+    })
+
+    const { result } = renderHook(() => useRefreshStatus({ pollIntervalMs: 1000, timeoutMs: 4000 }))
+
+    await act(async () => {
+      const promise = result.current.startRefresh()
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      await promise
+    })
+
+    expect(fetchRefreshStatusMock).toHaveBeenCalledTimes(2)
+    expect(result.current.pendingToasts.at(-1)).toMatchObject({ variant: 'success' })
+
+    fetchRefreshStatusMock.mockReset()
+    postRefreshMock.mockResolvedValueOnce({ state: 'running' })
+    const failures: RefreshStatusResponse[] = [
+      createStatus('running'),
+      createStatus('failure', { last_error: 'boom' }),
+    ]
+    fetchRefreshStatusMock.mockImplementation(async () => {
+      const next = failures.shift()
+      if (!next) throw new Error('no status')
+      return next
+    })
+
+    await act(async () => {
+      const promise = result.current.startRefresh()
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      await promise
+    })
+
+    expect(result.current.pendingToasts.at(-1)).toMatchObject({ variant: 'error', detail: 'boom' })
+
+    fetchRefreshStatusMock.mockReset()
+    postRefreshMock.mockResolvedValueOnce({ state: 'running' })
+    fetchRefreshStatusMock.mockResolvedValue(createStatus('running'))
+
+    await act(async () => {
+      const promise = result.current.startRefresh()
+      await vi.advanceTimersByTimeAsync(4000)
+      await promise
+    })
+
+    expect(result.current.pendingToasts.at(-1)).toMatchObject({ variant: 'warning' })
+    expect(fetchRefreshStatusMock.mock.calls.length).toBeGreaterThan(1)
+    expect(result.current.isRefreshing).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useRefreshStatus.ts
+++ b/frontend/src/hooks/useRefreshStatus.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { fetchRefreshStatus, postRefresh } from '../lib/api'
+import type { RefreshState, RefreshStatusResponse } from '../types'
+
+export type RefreshToastVariant = 'success' | 'error' | 'warning'
+
+export interface RefreshToast {
+  readonly id: string
+  readonly variant: RefreshToastVariant
+  readonly message: string
+  readonly detail?: string | null
+}
+
+export interface UseRefreshStatusOptions {
+  readonly pollIntervalMs?: number
+  readonly timeoutMs?: number
+}
+
+export interface UseRefreshStatusResult {
+  readonly isRefreshing: boolean
+  readonly pendingToasts: ReadonlyArray<RefreshToast>
+  readonly startRefresh: () => Promise<void>
+  readonly dismissToast: (id: string) => void
+}
+
+type ToastPayload = Omit<RefreshToast, 'id'>
+
+const TERMINAL_STATES: ReadonlySet<RefreshState> = new Set(['success', 'failure', 'stale'])
+
+const buildStatus = (state: RefreshState, overrides: Partial<RefreshStatusResponse> = {}): RefreshStatusResponse => ({
+  state,
+  started_at: overrides.started_at ?? null,
+  finished_at: overrides.finished_at ?? null,
+  updated_records: overrides.updated_records ?? 0,
+  last_error: overrides.last_error ?? null,
+})
+
+const toastFromStatus = (status: RefreshStatusResponse): ToastPayload => {
+  if (status.state === 'success') {
+    return { variant: 'success', message: 'データ更新が完了しました', detail: `更新件数: ${status.updated_records}` }
+  }
+  if (status.state === 'failure') {
+    return { variant: 'error', message: 'データ更新に失敗しました', detail: status.last_error }
+  }
+  return {
+    variant: 'warning',
+    message: 'データ更新の結果を取得できませんでした',
+    detail: '更新状況を確認できませんでした。時間をおいて再試行してください。',
+  }
+}
+
+export const useRefreshStatus = (options?: UseRefreshStatusOptions): UseRefreshStatusResult => {
+  const settings = useMemo(
+    () => ({ pollIntervalMs: options?.pollIntervalMs ?? 2000, timeoutMs: options?.timeoutMs ?? 120000 }),
+    [options?.pollIntervalMs, options?.timeoutMs],
+  )
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [pendingToasts, setPendingToasts] = useState<RefreshToast[]>([])
+  const active = useRef(false)
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const timeoutTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const completion = useRef<(() => void) | null>(null)
+  const toastSeq = useRef(0)
+
+  const enqueue = useCallback((toast: ToastPayload) => {
+    setPendingToasts((prev) => [...prev, { ...toast, id: String(++toastSeq.current) }])
+  }, [])
+
+  const dismissToast = useCallback((id: string) => {
+    setPendingToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  const clearTimers = useCallback(() => {
+    if (pollTimer.current) {
+      clearTimeout(pollTimer.current)
+      pollTimer.current = null
+    }
+    if (timeoutTimer.current) {
+      clearTimeout(timeoutTimer.current)
+      timeoutTimer.current = null
+    }
+  }, [])
+
+  const finish = useCallback(
+    (toast?: ToastPayload) => {
+      if (!active.current) return
+      active.current = false
+      clearTimers()
+      setIsRefreshing(false)
+      completion.current?.()
+      completion.current = null
+      if (toast) enqueue(toast)
+    },
+    [clearTimers, enqueue],
+  )
+
+  useEffect(() => () => finish(), [finish])
+
+  const poll = useCallback(async (): Promise<void> => {
+    if (!active.current) return
+    try {
+      const status = await fetchRefreshStatus()
+      if (!active.current) return
+      if (TERMINAL_STATES.has(status.state)) {
+        finish(toastFromStatus(status))
+        return
+      }
+      pollTimer.current = setTimeout(() => {
+        void poll()
+      }, settings.pollIntervalMs)
+    } catch (error) {
+      finish({
+        variant: 'error',
+        message: '更新状況の取得に失敗しました',
+        detail: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }, [finish, settings.pollIntervalMs])
+
+  const startRefresh = useCallback(async () => {
+    if (active.current) return
+    active.current = true
+    setIsRefreshing(true)
+    const completionPromise = new Promise<void>((resolve) => {
+      completion.current = resolve
+    })
+
+    timeoutTimer.current = setTimeout(() => {
+      finish({ variant: 'warning', message: '更新状況の取得がタイムアウトしました', detail: null })
+    }, settings.timeoutMs)
+
+    try {
+      const response = await postRefresh()
+      if (!active.current) return
+      if (TERMINAL_STATES.has(response.state)) {
+        finish(toastFromStatus(buildStatus(response.state)))
+      } else {
+        void poll()
+      }
+    } catch (error) {
+      finish({
+        variant: 'error',
+        message: '更新リクエストに失敗しました',
+        detail: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    await completionPromise
+  }, [finish, poll, settings.timeoutMs])
+
+  return { isRefreshing, pendingToasts, startRefresh, dismissToast }
+}


### PR DESCRIPTION
## Summary
- add vitest coverage that exercises the refresh status polling scenarios with fake timers
- implement a `useRefreshStatus` hook that posts the refresh request, polls status until completion, and queues toast metadata

## Testing
- npm run test -- useRefreshStatus

------
https://chatgpt.com/codex/tasks/task_e_68e14956fec08321bcf595ff53d7bde0