### PR TITLE
Support Japanese date strings for week normalization

### DIFF
--- a/frontend/src/hooks/recommendations/weekNormalization.ts
+++ b/frontend/src/hooks/recommendations/weekNormalization.ts
@@ -1,17 +1,30 @@
 import * as weekModule from '../../lib/week'
 
 const week = weekModule as typeof import('../../lib/week')
-const { normalizeIsoWeek, getCurrentIsoWeek } = week
+const { normalizeIsoWeek } = week
+
+const MS_IN_WEEK = 604800000
+
+const getIsoWeekFromDate = (date: Date): string => {
+  const thursday = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  const day = thursday.getUTCDay() || 7
+  thursday.setUTCDate(thursday.getUTCDate() + 4 - day)
+  const firstThursday = new Date(Date.UTC(thursday.getUTCFullYear(), 0, 4))
+  const diff = thursday.getTime() - firstThursday.getTime()
+  const weekNumber = Math.floor(diff / MS_IN_WEEK) + 1
+  const padded = Math.max(1, Math.min(weekNumber, 53)).toString().padStart(2, '0')
+  return `${thursday.getUTCFullYear()}-W${padded}`
+}
 
 export const normalizeWeekInput = (value: string, activeWeek: string): string => {
   const trimmed = value.trim()
   if (trimmed) {
-    const dateLike = trimmed.match(/^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})$/)
-    if (dateLike) {
-      const [, yearPart, , monthPart, dayPart] = dateLike
-      const year = Number(yearPart)
-      const month = Number(monthPart)
-      const day = Number(dayPart)
+    const normalized = trimmed.normalize('NFKC')
+    const getIsoWeekFromDateParts = (
+      year: number,
+      month: number,
+      day: number,
+    ): string | undefined => {
       if (
         Number.isInteger(year) &&
         Number.isInteger(month) &&
@@ -27,12 +40,35 @@ export const normalizeWeekInput = (value: string, activeWeek: string): string =>
           utcDate.getUTCMonth() === month - 1 &&
           utcDate.getUTCDate() === day
         ) {
-          return getCurrentIsoWeek(utcDate)
+          return getIsoWeekFromDate(utcDate)
         }
       }
+      return undefined
     }
 
-    const upper = trimmed.toUpperCase()
+    const japaneseDateLike = normalized.match(/^([0-9]{4})年\s*([0-9]{1,2})月\s*([0-9]{1,2})日$/)
+    if (japaneseDateLike) {
+      const [, yearPart, monthPart, dayPart] = japaneseDateLike
+      const isoWeek = getIsoWeekFromDateParts(
+        Number(yearPart),
+        Number(monthPart),
+        Number(dayPart),
+      )
+      if (isoWeek) return isoWeek
+    }
+
+    const dateLike = normalized.match(/^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})$/)
+    if (dateLike) {
+      const [, yearPart, , monthPart, dayPart] = dateLike
+      const isoWeek = getIsoWeekFromDateParts(
+        Number(yearPart),
+        Number(monthPart),
+        Number(dayPart),
+      )
+      if (isoWeek) return isoWeek
+    }
+
+    const upper = normalized.toUpperCase()
     const weekFirstMatch = upper.match(/^W?(\d{1,2})\D+(\d{4})$/)
     if (weekFirstMatch) {
       const weekPart = weekFirstMatch[1]

--- a/frontend/src/hooks/useRecommendationLoader.test.ts
+++ b/frontend/src/hooks/useRecommendationLoader.test.ts
@@ -10,6 +10,7 @@ describe('normalizeWeekInput', () => {
     ['2024-07-01', '2024-W27'],
     ['2024/07/01', '2024-W27'],
     ['2024.07.01', '2024-W27'],
+    ['2024年7月1日', '2024-W27'],
   ])('入力 %s は %s へ正規化される', (input, expected) => {
     expect(normalizeWeekInput(input, '2024-W05')).toBe(expected)
   })

--- a/frontend/tests/recommendations/weekNormalization.test.tsx
+++ b/frontend/tests/recommendations/weekNormalization.test.tsx
@@ -80,6 +80,34 @@ describe('App recommendations / 週入力正規化', () => {
     })
   })
 
+  it('和文日付を 2024-W27 に整形して送信する', async () => {
+    fetchCrops.mockResolvedValue(defaultCrops.slice(0, 2))
+    fetchRecommendations.mockImplementation(async (region, week) => {
+      const resolvedWeek = week ?? '2024-W30'
+      return createRecommendResponse({
+        week: resolvedWeek,
+        region,
+        items: [createItem({ crop: '春菊' })],
+      })
+    })
+
+    const { user } = await renderApp()
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W30')
+    })
+
+    const weekInput = screen.getByLabelText('週')
+    await user.clear(weekInput)
+    await user.type(weekInput, '2024年7月1日')
+    expect(weekInput).toHaveValue('2024年7月1日')
+    await user.click(screen.getByRole('button', { name: 'この条件で見る' }))
+
+    await waitFor(() => {
+      expect(fetchRecommendations).toHaveBeenLastCalledWith('temperate', '2024-W27')
+    })
+  })
+
   it('週番号が1桁の場合もゼロ埋めして送信する', async () => {
     fetchCrops.mockResolvedValue(defaultCrops.slice(0, 2))
     fetchRecommendations.mockImplementation(async (region, week) => {


### PR DESCRIPTION
## Summary
- add regression test ensuring Japanese-formatted dates are normalized to ISO weeks before requesting recommendations
- extend week normalization logic to parse Japanese year/month/day strings via UTC conversion
- cover Japanese date input in unit tests for normalizeWeekInput

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e17540c8c8832184bb081ed2068e32