### PR TITLE
Add reloadCurrentWeek support for recommendations hook

### DIFF
--- a/frontend/src/hooks/recommendations/controller.ts
+++ b/frontend/src/hooks/recommendations/controller.ts
@@ -20,6 +20,7 @@ export interface UseRecommendationsResult {
   displayWeek: string
   sortedRows: RecommendationRow[]
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void
+  reloadCurrentWeek: () => Promise<void>
 }
 
 export const useRecommendations = ({ favorites, initialRegion }: UseRecommendationsOptions): UseRecommendationsResult => {
@@ -37,6 +38,27 @@ export const useRecommendations = ({ favorites, initialRegion }: UseRecommendati
   }, [cropCatalog])
   const { queryWeek, setQueryWeek: setRawQueryWeek, activeWeek, items, currentWeek, requestRecommendations } =
     useRecommendationLoader(region)
+  const latestRegionRef = useRef(region)
+  const latestWeekRef = useRef(currentWeek)
+  const requestRef = useRef(requestRecommendations)
+
+  useEffect(() => {
+    latestRegionRef.current = region
+  }, [region])
+
+  useEffect(() => {
+    latestWeekRef.current = currentWeek
+  }, [currentWeek])
+
+  useEffect(() => {
+    requestRef.current = requestRecommendations
+  }, [requestRecommendations])
+
+  const reloadCurrentWeek = useCallback(() => {
+    return requestRef.current(latestWeekRef.current, {
+      regionOverride: latestRegionRef.current,
+    })
+  }, [])
 
   const setQueryWeek = useCallback(
     (nextWeek: string) => {
@@ -103,6 +125,7 @@ export const useRecommendations = ({ favorites, initialRegion }: UseRecommendati
     displayWeek,
     sortedRows,
     handleSubmit,
+    reloadCurrentWeek,
   }
 }
 


### PR DESCRIPTION
## Summary
- add coverage ensuring useRecommendations exposes a stable reloadCurrentWeek that re-fetches the last region/week
- implement reloadCurrentWeek in the recommendations controller by replaying the most recent request parameters

## Testing
- npm run test -- useRecommendations

------
https://chatgpt.com/codex/tasks/task_e_68e1752cc6e88321827c8a7accf5ceee