### PR TITLE
feat: reload recommendations after refresh

### DIFF
--- a/frontend/src/app.refresh.test.tsx
+++ b/frontend/src/app.refresh.test.tsx
@@ -132,7 +132,13 @@ describe('App refresh', () => {
         },
       ],
     })
-    fetchPrice.mockResolvedValue({ crop: '春菊', unit: 'kg', prices: [] })
+    fetchPrice.mockResolvedValue({
+      crop_id: 1,
+      crop: '春菊',
+      unit: 'kg',
+      source: 'local-db',
+      prices: [],
+    })
 
     await renderApp()
 

--- a/frontend/src/app.refresh.test.tsx
+++ b/frontend/src/app.refresh.test.tsx
@@ -1,10 +1,11 @@
 import '@testing-library/jest-dom/vitest'
-import { cleanup, fireEvent, screen, within } from '@testing-library/react'
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   fetchCrops,
   fetchRecommend,
+  fetchPrice,
   fetchRefreshStatus,
   fetchRecommendations,
   postRefresh,
@@ -78,17 +79,22 @@ describe('App refresh', () => {
     await Promise.resolve()
     expect(fetchRefreshStatus).toHaveBeenCalledTimes(1)
 
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
     await Promise.resolve()
     expect(fetchRefreshStatus).toHaveBeenCalledTimes(2)
 
     const successToasts = within(main).getAllByRole('alert')
-    expect(successToasts.some((toast) => toast.textContent?.includes('3件'))).toBe(true)
+    expect(
+      successToasts.some(
+        (toast) =>
+          toast.textContent?.includes('データ更新が完了しました') && toast.textContent?.includes('更新件数: 3'),
+      ),
+    ).toBe(true)
     expect(refreshButton).not.toBeDisabled()
 
     await vi.advanceTimersByTimeAsync(5000)
     await Promise.resolve()
-    expect(within(main).queryByText(/3件/)).not.toBeInTheDocument()
+    expect(within(main).queryByText(/更新件数: 3/)).not.toBeInTheDocument()
 
     fireEvent.click(refreshButton)
     expect(refreshButton).toBeDisabled()
@@ -99,7 +105,88 @@ describe('App refresh', () => {
     await Promise.resolve()
     await Promise.resolve()
     const failureToasts = within(main).getAllByRole('alert')
-    expect(failureToasts.some((toast) => toast.textContent?.includes('network'))).toBe(true)
+    expect(
+      failureToasts.some(
+        (toast) =>
+          toast.textContent?.includes('データ更新に失敗しました') && toast.textContent?.includes('network'),
+      ),
+    ).toBe(true)
     expect(refreshButton).not.toBeDisabled()
+  })
+
+  it('更新成功時に推薦と価格データを再取得する', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+      { id: 2, name: 'にんじん', category: 'root' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [
+        {
+          crop: '春菊',
+          harvest_week: '2024-W35',
+          sowing_week: '2024-W30',
+          source: 'local-db',
+          growth_days: 35,
+        },
+      ],
+    })
+    fetchPrice.mockResolvedValue({ crop: '春菊', unit: 'kg', prices: [] })
+
+    await renderApp()
+
+    const refreshButton = screen.getByRole('button', { name: '更新' })
+    const main = screen.getByRole('main')
+    const recommendationRow = await screen.findByRole('row', { name: /春菊/ })
+    fireEvent.click(recommendationRow)
+    expect(fetchPrice).toHaveBeenCalledTimes(1)
+
+    vi.useFakeTimers()
+
+    postRefresh.mockResolvedValue({ state: 'running' })
+    fetchRefreshStatus
+      .mockResolvedValueOnce({
+        state: 'running',
+        started_at: '2024-01-01T00:00:00Z',
+        finished_at: null,
+        updated_records: 0,
+        last_error: null,
+      })
+      .mockResolvedValueOnce({
+        state: 'success',
+        started_at: '2024-01-01T00:00:00Z',
+        finished_at: '2024-01-01T00:00:10Z',
+        updated_records: 5,
+        last_error: null,
+      })
+
+    fireEvent.click(refreshButton)
+
+    await Promise.resolve()
+    expect(postRefresh).toHaveBeenCalledTimes(1)
+    expect(fetchRefreshStatus).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(2000)
+    await Promise.resolve()
+    expect(fetchRefreshStatus).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      const totalCalls = fetchRecommendations.mock.calls.length + fetchRecommend.mock.calls.length
+      expect(totalCalls).toBeGreaterThanOrEqual(2)
+    })
+
+    const toasts = within(main).getAllByRole('alert')
+    expect(
+      toasts.some(
+        (toast) =>
+          toast.textContent?.includes('データ更新が完了しました') && toast.textContent?.includes('更新件数: 5'),
+      ),
+    ).toBe(true)
+
+    await waitFor(() => {
+      expect(fetchPrice).toHaveBeenCalledTimes(2)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- replace App toast handling with the shared useRefreshStatus hook and auto-dismiss timers
- refresh recommendation data and remount the price chart when a refresh succeeds so selected crops reload pricing
- extend the refresh tests to assert recommendation reload, toast messages, and price reload behaviour

## Testing
- npm run test -- app.refresh

------
https://chatgpt.com/codex/tasks/task_e_68e1752ddb4c8321ba42b30e3a6da633