### PR TITLE
Normalize full-width inputs for week normalization

### DIFF
--- a/frontend/src/hooks/recommendations/weekNormalization.ts
+++ b/frontend/src/hooks/recommendations/weekNormalization.ts
@@ -89,6 +89,7 @@ export const normalizeWeekInput = (value: string, activeWeek: string): string =>
       const weekPart = digits.slice(4)
       if (weekPart) return normalizeIsoWeek(`${yearPart}-W${weekPart.padStart(2, '0')}`, activeWeek)
     }
+    return normalizeIsoWeek(normalized, activeWeek)
   }
   return normalizeIsoWeek(value, activeWeek)
 }

--- a/frontend/src/hooks/useRecommendationLoader.test.ts
+++ b/frontend/src/hooks/useRecommendationLoader.test.ts
@@ -11,6 +11,8 @@ describe('normalizeWeekInput', () => {
     ['2024/07/01', '2024-W27'],
     ['2024.07.01', '2024-W27'],
     ['2024年7月1日', '2024-W27'],
+    ['２０２４－Ｗ６', '2024-W06'],
+    ['２０２４／０７／０１', '2024-W27'],
   ])('入力 %s は %s へ正規化される', (input, expected) => {
     expect(normalizeWeekInput(input, '2024-W05')).toBe(expected)
   })


### PR DESCRIPTION
## Summary
- add regression tests ensuring normalizeWeekInput accepts full-width week and date strings
- route unmatched inputs through normalizeIsoWeek using NFKC-normalized text to guarantee ASCII week strings

## Testing
- npm run typecheck
- npm run test -- --reporter basic

------
https://chatgpt.com/codex/tasks/task_e_68e1d82701508321ad035700cd7b76b8