### PR TITLE
feat: surface refresh warnings and toast dismiss button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,145 +1,20 @@
 
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChangeEvent, useCallback, useMemo, useRef, useState } from 'react'
 
 import { PriceChartSection } from './components/PriceChartSection'
 import { RecommendationsTable } from './components/RecommendationsTable'
 import { SearchControls } from './components/SearchControls'
 import { useFavorites } from './components/FavStar'
-import { fetchRefreshStatus, postRefresh } from './lib/api'
 import { loadRegion } from './lib/storage'
 import { useRecommendations } from './hooks/useRecommendations'
+import { useRefreshStatus } from './hooks/useRefreshStatus'
 import type { Region } from './types'
 
 import './App.css'
 
-type ToastTone = 'info' | 'success' | 'error'
-
-interface RefreshToast {
-  id: number
-  message: string
-  tone: ToastTone
-}
-
-const POLL_INTERVAL_MS = 1000
-const TOAST_DURATION_MS = 5000
-
-const useRefreshStatus = () => {
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const [toasts, setToasts] = useState<RefreshToast[]>([])
-  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const toastTimersRef = useRef(new Map<number, ReturnType<typeof setTimeout>>())
-  const nextToastIdRef = useRef(0)
-
-  const clearPollTimer = useCallback(() => {
-    if (pollTimerRef.current) {
-      clearTimeout(pollTimerRef.current)
-      pollTimerRef.current = null
-    }
-  }, [])
-
-  const removeToast = useCallback((id: number) => {
-    const timer = toastTimersRef.current.get(id)
-    if (timer) {
-      clearTimeout(timer)
-      toastTimersRef.current.delete(id)
-    }
-    setToasts((prev) => prev.filter((toast) => toast.id !== id))
-  }, [])
-
-  const pushToast = useCallback(
-    (toast: Omit<RefreshToast, 'id'>) => {
-      const id = nextToastIdRef.current++
-      setToasts((prev) => [...prev, { ...toast, id }])
-      const timer = setTimeout(() => {
-        removeToast(id)
-      }, TOAST_DURATION_MS)
-      toastTimersRef.current.set(id, timer)
-    },
-    [removeToast],
-  )
-
-  const pollStatus = useCallback(async () => {
-    let shouldContinue = false
-    try {
-      const status = await fetchRefreshStatus()
-      if (status.state === 'running' || status.state === 'stale') {
-        shouldContinue = true
-        return
-      }
-      if (status.state === 'success') {
-        pushToast({
-          tone: 'success',
-          message: `更新が完了しました。${status.updated_records}件のデータを更新しました。`,
-        })
-      } else if (status.state === 'failure') {
-        const detail = status.last_error ?? '詳細不明のエラー'
-        pushToast({
-          tone: 'error',
-          message: `更新が失敗しました: ${detail}`,
-        })
-      } else {
-        pushToast({
-          tone: 'info',
-          message: '更新ステータスが不明です。',
-        })
-      }
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error)
-      pushToast({
-        tone: 'error',
-        message: `更新ステータスの取得に失敗しました: ${detail}`,
-      })
-    } finally {
-      if (shouldContinue) {
-        clearPollTimer()
-        pollTimerRef.current = setTimeout(() => {
-          void pollStatus()
-        }, POLL_INTERVAL_MS)
-      } else {
-        clearPollTimer()
-        setIsRefreshing(false)
-      }
-    }
-  }, [clearPollTimer, pushToast])
-
-  const startRefresh = useCallback(async () => {
-    if (isRefreshing) {
-      return
-    }
-    setIsRefreshing(true)
-    try {
-      const response = await postRefresh()
-      if (response.state === 'failure') {
-        pushToast({ tone: 'error', message: '更新リクエストに失敗しました。' })
-        setIsRefreshing(false)
-        return
-      }
-      pushToast({ tone: 'info', message: '更新を開始しました。進行状況を確認しています…' })
-      clearPollTimer()
-      void pollStatus()
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error)
-      pushToast({ tone: 'error', message: `更新リクエストに失敗しました: ${detail}` })
-      setIsRefreshing(false)
-    }
-  }, [clearPollTimer, isRefreshing, pollStatus, pushToast])
-
-  useEffect(() => {
-    return () => {
-      clearPollTimer()
-      toastTimersRef.current.forEach((timer) => {
-        clearTimeout(timer)
-      })
-      toastTimersRef.current.clear()
-    }
-  }, [clearPollTimer])
-
-  return { isRefreshing, startRefresh, toasts }
-}
-
 export const App = () => {
   const [selectedCropId, setSelectedCropId] = useState<number | null>(null)
-  const { isRefreshing, startRefresh, toasts } = useRefreshStatus()
+  const { isRefreshing, startRefresh, pendingToasts, dismissToast } = useRefreshStatus()
   const { favorites, toggleFavorite, isFavorite } = useFavorites()
   const [searchKeyword, setSearchKeyword] = useState('')
 
@@ -205,11 +80,17 @@ export const App = () => {
         />
       </header>
       <main className="app__main">
-        {toasts.length > 0 && (
+        {pendingToasts.length > 0 && (
           <div className="toast-stack" aria-live="assertive" aria-atomic="true">
-            {toasts.map((toast) => (
-              <div key={toast.id} className={`toast toast--${toast.tone}`} role="alert">
-                {toast.message}
+            {pendingToasts.map((toast) => (
+              <div key={toast.id} className={`toast toast--${toast.variant}`} role="alert">
+                <div className="toast__content">
+                  <p className="toast__message">{toast.message}</p>
+                  {toast.detail ? <p className="toast__detail">{toast.detail}</p> : null}
+                </div>
+                <button type="button" className="toast__close" onClick={() => dismissToast(toast.id)}>
+                  閉じる
+                </button>
               </div>
             ))}
           </div>

--- a/frontend/src/app.refresh.test.tsx
+++ b/frontend/src/app.refresh.test.tsx
@@ -78,17 +78,20 @@ describe('App refresh', () => {
     await Promise.resolve()
     expect(fetchRefreshStatus).toHaveBeenCalledTimes(1)
 
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
     await Promise.resolve()
     expect(fetchRefreshStatus).toHaveBeenCalledTimes(2)
 
-    const successToasts = within(main).getAllByRole('alert')
-    expect(successToasts.some((toast) => toast.textContent?.includes('3件'))).toBe(true)
-    expect(refreshButton).not.toBeDisabled()
-
-    await vi.advanceTimersByTimeAsync(5000)
     await Promise.resolve()
-    expect(within(main).queryByText(/3件/)).not.toBeInTheDocument()
+    const successMessage = within(main).getByText('データ更新が完了しました')
+    const successToast = successMessage.closest('.toast') as HTMLElement | null
+    expect(successToast).not.toBeNull()
+    const successToastEl = successToast as HTMLElement
+    expect(successToastEl).toHaveClass('toast--success')
+    expect(successToastEl).toHaveTextContent('更新件数: 3')
+    const successCloseButton = within(successToastEl).getByRole('button', { name: '閉じる' })
+    fireEvent.click(successCloseButton)
+    expect(refreshButton).not.toBeDisabled()
 
     fireEvent.click(refreshButton)
     expect(refreshButton).toBeDisabled()
@@ -98,8 +101,100 @@ describe('App refresh', () => {
 
     await Promise.resolve()
     await Promise.resolve()
-    const failureToasts = within(main).getAllByRole('alert')
-    expect(failureToasts.some((toast) => toast.textContent?.includes('network'))).toBe(true)
+    await Promise.resolve()
+    const failureMessage = within(main).getByText('データ更新に失敗しました')
+    const failureToast = failureMessage.closest('.toast') as HTMLElement | null
+    expect(failureToast).not.toBeNull()
+    const failureToastEl = failureToast as HTMLElement
+    expect(failureToastEl).toHaveClass('toast--error')
+    expect(failureToastEl).toHaveTextContent('network')
+    expect(within(failureToastEl).getByRole('button', { name: '閉じる' })).toBeInTheDocument()
+    expect(refreshButton).not.toBeDisabled()
+  })
+
+  it('stale 応答で警告トーストと閉じるボタンを表示する', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+      { id: 2, name: 'にんじん', category: 'root' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    })
+
+    await renderApp()
+    vi.useFakeTimers()
+
+    const refreshButton = screen.getByRole('button', { name: '更新' })
+    const main = screen.getByRole('main')
+
+    postRefresh.mockResolvedValue({ state: 'running' })
+    fetchRefreshStatus.mockResolvedValueOnce({
+      state: 'stale',
+      started_at: '2024-01-01T00:00:00Z',
+      finished_at: '2024-01-01T00:00:05Z',
+      updated_records: 0,
+      last_error: null,
+    })
+
+    fireEvent.click(refreshButton)
+    expect(refreshButton).toBeDisabled()
+
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    const warningMessage = within(main).getByText('データ更新の結果を取得できませんでした')
+    const warningToast = warningMessage.closest('.toast') as HTMLElement | null
+    expect(warningToast).not.toBeNull()
+    const warningToastEl = warningToast as HTMLElement
+    expect(warningToastEl).toHaveClass('toast--warning')
+    expect(warningToastEl).toHaveTextContent('時間をおいて再試行してください')
+    const closeButton = within(warningToastEl).getByRole('button', { name: '閉じる' })
+    fireEvent.click(closeButton)
+    expect(refreshButton).not.toBeDisabled()
+  })
+
+  it('タイムアウトで警告トーストを表示し閉じることができる', async () => {
+    fetchCrops.mockResolvedValue([
+      { id: 1, name: '春菊', category: 'leaf' },
+      { id: 2, name: 'にんじん', category: 'root' },
+    ])
+    fetchRecommendations.mockResolvedValue({
+      week: '2024-W30',
+      region: 'temperate',
+      items: [],
+    })
+
+    await renderApp()
+    vi.useFakeTimers()
+
+    const refreshButton = screen.getByRole('button', { name: '更新' })
+    const main = screen.getByRole('main')
+
+    postRefresh.mockResolvedValue({ state: 'running' })
+    fetchRefreshStatus.mockResolvedValue({
+      state: 'running',
+      started_at: '2024-01-01T00:00:00Z',
+      finished_at: null,
+      updated_records: 0,
+      last_error: null,
+    })
+
+    fireEvent.click(refreshButton)
+    expect(refreshButton).toBeDisabled()
+
+    await vi.advanceTimersByTimeAsync(120000)
+    await Promise.resolve()
+
+    await Promise.resolve()
+    const timeoutMessage = within(main).getByText('更新状況の取得がタイムアウトしました')
+    const timeoutToast = timeoutMessage.closest('.toast') as HTMLElement | null
+    expect(timeoutToast).not.toBeNull()
+    const timeoutToastEl = timeoutToast as HTMLElement
+    expect(timeoutToastEl).toHaveClass('toast--warning')
+    const closeButton = within(timeoutToastEl).getByRole('button', { name: '閉じる' })
+    fireEvent.click(closeButton)
     expect(refreshButton).not.toBeDisabled()
   })
 })


### PR DESCRIPTION
## Summary
- expand the refresh integration test to cover success, failure, stale, and timeout toast scenarios
- refactor the app to consume the shared refresh hook and render a dismissible toast stack with variants

## Testing
- npm run test -- app.refresh

------
https://chatgpt.com/codex/tasks/task_e_68e1d80bc8f88321ae53722424905439