### PR TITLE
Fix import ordering for ETL tests

### DIFF
--- a/backend/tests/test_etl.py
+++ b/backend/tests/test_etl.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 # TODO [x] etl/test_schema.py へ移行完了
 # TODO [x] etl/test_runner.py へ移行完了
 # TODO [x] etl/test_retry.py へ移行完了
-
 from .etl import test_connection as _test_connection
 from .etl import test_retry as _test_retry
 from .etl import test_runner as _test_runner

--- a/backend/tests/test_etl_smoke.py
+++ b/backend/tests/test_etl_smoke.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import inspect
-from importlib import import_module
 import pkgutil
+from importlib import import_module
 from types import ModuleType
 
 ETL_PACKAGE = ".etl"


### PR DESCRIPTION
## Summary
- organize imports in backend legacy ETL shim to satisfy ruff
- sort standard-library imports in ETL smoke test module

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68e311c834f88321af90aa55b9e64b90