### PR TITLE
Format backend files with Black

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -20,6 +20,7 @@ from typing import Final, Protocol, cast
 _PACKAGE_ROOT = Path(__file__).with_name("db")
 __path__ = [str(_PACKAGE_ROOT)]
 
+
 class _ConnectionModule(Protocol):
     DB_LOCK: RLock
     DATABASE_FILE: Path
@@ -36,12 +37,8 @@ class _MigrationsModule(Protocol):
     def init_db(conn: sqlite3.Connection | None = None) -> None: ...
 
 
-_connection = cast(
-    _ConnectionModule, import_module("app.db.connection")
-)
-_migrations = cast(
-    _MigrationsModule, import_module("app.db.migrations")
-)
+_connection = cast(_ConnectionModule, import_module("app.db.connection"))
+_migrations = cast(_MigrationsModule, import_module("app.db.migrations"))
 
 DB_LOCK = _connection.DB_LOCK
 DATABASE_FILE: Final[Path] = _connection.DATABASE_FILE

--- a/backend/app/db/schema.py
+++ b/backend/app/db/schema.py
@@ -88,9 +88,7 @@ def _recreate_table_with_autoincrement(
     columns_cursor = conn.execute(f"PRAGMA table_info('{temp_table}')")
     columns = [str(row["name"]) for row in columns_cursor.fetchall()]
     column_list = ", ".join(columns)
-    conn.execute(
-        f"INSERT INTO {table} ({column_list}) SELECT {column_list} FROM {temp_table}"
-    )
+    conn.execute(f"INSERT INTO {table} ({column_list}) SELECT {column_list} FROM {temp_table}")
     conn.execute(f"DROP TABLE {temp_table}")
 
 

--- a/backend/app/seed/writers.py
+++ b/backend/app/seed/writers.py
@@ -17,7 +17,9 @@ def _optional_float(value: Any) -> float | None:
     raise TypeError(f"Unsupported numeric value: {value!r}")
 
 
-def _iter_price_records(crops: Iterable[Mapping[str, Any]]) -> Iterable[tuple[int, Mapping[str, Any]]]:
+def _iter_price_records(
+    crops: Iterable[Mapping[str, Any]],
+) -> Iterable[tuple[int, Mapping[str, Any]]]:
     for crop in crops:
         crop_id = int(crop["id"])
         for price in crop.get("price_weekly", []) or []:
@@ -62,7 +64,9 @@ def write_crops(conn: sqlite3.Connection, crops: Iterable[Mapping[str, Any]]) ->
         )
 
 
-def write_price_samples(conn: sqlite3.Connection, price_samples: Iterable[Mapping[str, Any]]) -> None:
+def write_price_samples(
+    conn: sqlite3.Connection, price_samples: Iterable[Mapping[str, Any]]
+) -> None:
     for row in price_samples:
         conn.execute(
             """

--- a/backend/tests/etl/test_retry.py
+++ b/backend/tests/etl/test_retry.py
@@ -24,9 +24,7 @@ def test_start_etl_job_records_failure_metadata(
 
     attempts: dict[str, int] = {"count": 0}
 
-    def failing_run_etl(
-        conn: sqlite3.Connection, *, data_loader: object | None = None
-    ) -> int:
+    def failing_run_etl(conn: sqlite3.Connection, *, data_loader: object | None = None) -> int:
         attempts["count"] += 1
         raise RuntimeError("boom")
 
@@ -69,9 +67,7 @@ def test_start_etl_job_retries_database_errors(
 
     attempts: dict[str, int] = {"count": 0}
 
-    def flaky_run_etl(
-        conn: sqlite3.Connection, *, data_loader: object | None = None
-    ) -> int:
+    def flaky_run_etl(conn: sqlite3.Connection, *, data_loader: object | None = None) -> int:
         attempts["count"] += 1
         raise sqlite3.OperationalError("db locked")
 

--- a/backend/tests/etl/test_schema.py
+++ b/backend/tests/etl/test_schema.py
@@ -25,13 +25,11 @@ def test_ensure_schema_backfills_missing_columns(tmp_path: Path) -> None:
 
         etl_runner._ensure_schema(conn)
 
-        columns = {
-            row["name"]
-            for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()
-        }
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info('etl_runs')").fetchall()}
         assert {"state", "started_at", "finished_at", "last_error"}.issubset(columns)
     finally:
         conn.close()
+
 
 def test_insert_run_metadata_persists_defaults() -> None:
     from app import db

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -69,7 +69,9 @@ def test_tables_use_autoincrement(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         conn.close()
 
 
-def test_get_conn_creates_db_with_foreign_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_conn_creates_db_with_foreign_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     test_db = tmp_path / "nested" / "schema.db"
     monkeypatch.setattr(db, "DATABASE_FILE", test_db)
 

--- a/backend/tests/test_etl_smoke.py
+++ b/backend/tests/test_etl_smoke.py
@@ -23,7 +23,9 @@ def _iter_etl_modules() -> list[str]:
 def _has_collectable_tests(module: ModuleType) -> bool:
     if any(name.startswith("test_") and callable(obj) for name, obj in inspect.getmembers(module)):
         return True
-    if any(name.startswith("Test") and inspect.isclass(obj) for name, obj in inspect.getmembers(module)):
+    if any(
+        name.startswith("Test") and inspect.isclass(obj) for name, obj in inspect.getmembers(module)
+    ):
         return True
     return False
 

--- a/backend/tests/test_seed_data.py
+++ b/backend/tests/test_seed_data.py
@@ -44,7 +44,9 @@ def seed_payload() -> data_loader.SeedPayload:
     )
 
 
-def test_seed_inserts_expected_records(monkeypatch: pytest.MonkeyPatch, seed_payload: data_loader.SeedPayload) -> None:
+def test_seed_inserts_expected_records(
+    monkeypatch: pytest.MonkeyPatch, seed_payload: data_loader.SeedPayload
+) -> None:
     monkeypatch.setattr(seed_module.db, "init_db", lambda conn: None)
     monkeypatch.setattr(seed_module, "load_seed_payload", lambda data_dir=None: seed_payload)
 
@@ -58,7 +60,10 @@ def test_seed_inserts_expected_records(monkeypatch: pytest.MonkeyPatch, seed_pay
         "INSERT OR IGNORE INTO crops (id, name, category) VALUES (?, ?, ?)",
         (1, "Lettuce", "Leafy"),
     ) in executed
-    assert ("UPDATE crops SET name = ?, category = ? WHERE id = ?", ("Lettuce", "Leafy", 1)) in executed
+    assert (
+        "UPDATE crops SET name = ?, category = ? WHERE id = ?",
+        ("Lettuce", "Leafy", 1),
+    ) in executed
 
     assert any(
         sql.startswith("INSERT OR REPLACE INTO price_weekly")
@@ -83,6 +88,9 @@ def test_seed_inserts_expected_records(monkeypatch: pytest.MonkeyPatch, seed_pay
         "INSERT OR IGNORE INTO growth_days (crop_id, region, days) VALUES (?, ?, ?)",
         (1, "tokyo", 65),
     ) in executed
-    assert ("UPDATE growth_days SET days = ? WHERE crop_id = ? AND region = ?", (65, 1, "tokyo")) in executed
+    assert (
+        "UPDATE growth_days SET days = ? WHERE crop_id = ? AND region = ?",
+        (65, 1, "tokyo"),
+    ) in executed
 
     conn.commit.assert_called_once_with()


### PR DESCRIPTION
## Summary
- apply Black formatting to backend database and seed modules
- format backend ETL and schema tests to satisfy the Black check

## Testing
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68e312e0c10883218dc57782bf310124